### PR TITLE
fix: size Markdown pipe tables to content instead of 100% width

### DIFF
--- a/Sources/SwiftTextCLI/PDFCommand.swift
+++ b/Sources/SwiftTextCLI/PDFCommand.swift
@@ -412,7 +412,7 @@ func markdownToHTML(_ markdown: String, paper: PaperSize, landscape: Bool) -> St
 	    white-space: pre-wrap;
 	    word-break: break-all;
 	}
-	table { border-collapse: collapse; width: 100%; margin: 0.8em 0; font-size: 0.95em; }
+	table { border-collapse: collapse; margin: 0.8em 0; font-size: 0.95em; }
 	th, td { border: 1px solid #999; padding: 0.4em 0.7em; text-align: left; }
 	th { background: #dcdcdc; font-weight: 600; }
 	tr:nth-child(even) td { background: #f9f9f9; }

--- a/Sources/SwiftTextHTML/MarkdownToHTML.swift
+++ b/Sources/SwiftTextHTML/MarkdownToHTML.swift
@@ -187,7 +187,7 @@ public enum MarkdownToHTML {
 	    font-size: 10pt; white-space: pre-wrap; word-break: break-all;
 	}
 	pre code { background: none; border: none; padding: 0; font-size: inherit; }
-	table { border-collapse: collapse; width: 100%; margin: 0.8em 0; font-size: 0.95em; }
+	table { border-collapse: collapse; margin: 0.8em 0; font-size: 0.95em; }
 	th, td { border: 1px solid #999; padding: 0.4em 0.7em; text-align: left; }
 	th { background: #dcdcdc; font-weight: 600; }
 	tr:nth-child(even) td { background: #f9f9f9; }


### PR DESCRIPTION
## Summary
- Removes `width: 100%` from the table CSS rule in both the default HTML stylesheet (`MarkdownToHTML.swift`) and the CLI/PDF stylesheet (`PDFCommand.swift`)
- Tables now auto-size to fit their content instead of stretching to full container width

Fixes #6

## Test plan
- [x] All 37 existing tests pass
- [ ] Verify rendered HTML tables from Markdown pipe syntax are content-sized, not full-width

🤖 Generated with [Claude Code](https://claude.com/claude-code)