### PR TITLE
Sanitize Unicode grapheme cluster abuse

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,7 +104,7 @@ let htmlTargets: [Target] = [
 	),
 	.testTarget(
 		name: "SwiftTextHTMLTests",
-		dependencies: ["SwiftTextHTML"],
+		dependencies: ["SwiftTextHTML", "SwiftTextCore"],
 		path: "Tests/SwiftTextHTMLTests"
 	),
 ] + xmlSystemTargets

--- a/Package.swift
+++ b/Package.swift
@@ -119,6 +119,10 @@ let packageProducts: [Product] = [
 		targets: ["SwiftText"]
 	),
 	.library(
+		name: "SwiftTextCore",
+		targets: ["SwiftTextCore"]
+	),
+	.library(
 		name: "SwiftTextDOCX",
 		targets: ["SwiftTextDOCX"]
 	),
@@ -129,6 +133,10 @@ let swiftTextDependencies: [Target.Dependency] = [
 ] + swiftTextHTMLDeps + swiftTextExtraDeps
 
 let packageTargets: [Target] = [
+	.target(
+		name: "SwiftTextCore",
+		path: "Sources/SwiftTextCore"
+	),
 	.target(
 		name: "SwiftText",
 		dependencies: swiftTextDependencies,
@@ -148,6 +156,11 @@ let packageTargets: [Target] = [
 		resources: [
 			.process("Resources"),
 		]
+	),
+	.testTarget(
+		name: "SwiftTextCoreTests",
+		dependencies: ["SwiftTextCore"],
+		path: "Tests/SwiftTextCoreTests"
 	),
 ] + htmlTargets + macOSTargets
 

--- a/Sources/SwiftTextCore/UnicodeAbuseSanitizer.swift
+++ b/Sources/SwiftTextCore/UnicodeAbuseSanitizer.swift
@@ -61,7 +61,6 @@ public enum UnicodeAbuseSanitizer {
 		let keptTagIndices = validTagIndices(in: scalars)
 		var result: [UnicodeScalar] = []
 		var combiningCount = 0
-		var variationSelectorCount = 0
 		var hasTrimmedCombiningMarks = false
 		var nonZWJScalarCount = 0
 
@@ -81,9 +80,8 @@ public enum UnicodeAbuseSanitizer {
 			}
 
 			if isVariationSelector(scalar) {
-				if variationSelectorCount < maximumAllowedVariationSelectors {
+				if canAppendVariationSelector(to: result) {
 					result.append(scalar)
-					variationSelectorCount += 1
 				}
 				continue
 			}
@@ -159,6 +157,13 @@ public enum UnicodeAbuseSanitizer {
 
 	private static func isCombiningMark(_ scalar: UnicodeScalar) -> Bool {
 		CharacterSet.nonBaseCharacters.contains(scalar)
+	}
+
+	private static func canAppendVariationSelector(to scalars: [UnicodeScalar]) -> Bool {
+		guard let previousScalar = scalars.last else {
+			return false
+		}
+		return !isVariationSelector(previousScalar)
 	}
 
 	private static func isVariationSelector(_ scalar: UnicodeScalar) -> Bool {

--- a/Sources/SwiftTextCore/UnicodeAbuseSanitizer.swift
+++ b/Sources/SwiftTextCore/UnicodeAbuseSanitizer.swift
@@ -1,0 +1,185 @@
+import Foundation
+
+public struct UnicodeAbuseReport: Equatable, Sendable {
+	public var maxClusterSize: Int = 0
+	public var excessiveCombiningMarks: Int = 0
+	public var zwjChainLength: Int = 0
+	public var hasBidiOverrides = false
+	public var hasTagAbuse = false
+
+	public var containsAbuse: Bool {
+		maxClusterSize > UnicodeAbuseSanitizer.maximumSafeClusterScalars
+			|| excessiveCombiningMarks > 0
+			|| zwjChainLength > UnicodeAbuseSanitizer.maximumSafeZWJSequenceScalars
+			|| hasBidiOverrides
+			|| hasTagAbuse
+	}
+}
+
+public struct UnicodeSanitizationResult: Equatable, Sendable {
+	public let text: String
+	public let report: UnicodeAbuseReport
+}
+
+public enum UnicodeAbuseSanitizer {
+	private static let zeroWidthJoiner = UnicodeScalar(0x200D)!
+	private static let blackFlag = UnicodeScalar(0x1F3F4)!
+	private static let cancelTag = UnicodeScalar(0xE007F)!
+
+	static let maximumSafeClusterScalars = 50
+	static let maximumSafeOutputClusterScalars = 16
+	static let maximumAllowedCombiningMarks = 15
+	static let combiningMarkWarningThreshold = 5
+	static let maximumSafeZWJSequenceScalars = 11
+	static let maximumAllowedVariationSelectors = 1
+	static let maximumAllowedTagScalars = 8
+
+	public static func sanitize(_ text: String) -> UnicodeSanitizationResult {
+		guard !text.isEmpty else {
+			return UnicodeSanitizationResult(text: text, report: UnicodeAbuseReport())
+		}
+
+		var report = UnicodeAbuseReport()
+		var sanitized = String.UnicodeScalarView()
+
+		for character in text {
+			let scalars = Array(String(character).unicodeScalars)
+			report.maxClusterSize = max(report.maxClusterSize, scalars.count)
+			report.zwjChainLength = max(report.zwjChainLength, zwjChainLength(in: scalars))
+
+			let sanitizedCluster = sanitizeCluster(scalars, report: &report)
+			sanitized.append(contentsOf: sanitizedCluster)
+		}
+
+		let normalized = String(sanitized).precomposedStringWithCanonicalMapping
+		return UnicodeSanitizationResult(text: normalized, report: report)
+	}
+
+	private static func sanitizeCluster(_ scalars: [UnicodeScalar], report: inout UnicodeAbuseReport) -> [UnicodeScalar] {
+		guard !scalars.isEmpty else { return [] }
+
+		let keptTagIndices = validTagIndices(in: scalars)
+		var result: [UnicodeScalar] = []
+		var combiningCount = 0
+		var variationSelectorCount = 0
+		var hasTrimmedCombiningMarks = false
+		var nonZWJScalarCount = 0
+
+		for (index, scalar) in scalars.enumerated() {
+			if isBidiOverride(scalar) {
+				report.hasBidiOverrides = true
+				continue
+			}
+
+			if isTagScalar(scalar) {
+				if keptTagIndices.contains(index) {
+					result.append(scalar)
+				} else {
+					report.hasTagAbuse = true
+				}
+				continue
+			}
+
+			if isVariationSelector(scalar) {
+				if variationSelectorCount < maximumAllowedVariationSelectors {
+					result.append(scalar)
+					variationSelectorCount += 1
+				}
+				continue
+			}
+
+			if isCombiningMark(scalar) {
+				combiningCount += 1
+				if combiningCount <= maximumAllowedCombiningMarks {
+					result.append(scalar)
+				} else {
+					hasTrimmedCombiningMarks = true
+				}
+				continue
+			}
+
+			result.append(scalar)
+			if scalar != "\u{200D}" {
+				nonZWJScalarCount += 1
+			}
+
+			if scalar == zeroWidthJoiner, nonZWJScalarCount >= maximumSafeZWJSequenceScalars {
+				report.zwjChainLength = max(report.zwjChainLength, max(scalars.count, maximumSafeZWJSequenceScalars + 1))
+				break
+			}
+		}
+
+		if combiningCount > combiningMarkWarningThreshold {
+			report.excessiveCombiningMarks += 1
+		}
+
+		if hasTrimmedCombiningMarks {
+			report.excessiveCombiningMarks += 1
+		}
+
+		if result.count > maximumSafeOutputClusterScalars {
+			result = Array(result.prefix(maximumSafeOutputClusterScalars))
+		}
+
+		return result
+	}
+
+	private static func zwjChainLength(in scalars: [UnicodeScalar]) -> Int {
+		guard scalars.contains(zeroWidthJoiner) else {
+			return 0
+		}
+		return scalars.count
+	}
+
+	private static func validTagIndices(in scalars: [UnicodeScalar]) -> Set<Int> {
+		let tagIndices = scalars.indices.filter { isTagScalar(scalars[$0]) }
+		guard !tagIndices.isEmpty else { return [] }
+
+		guard scalars.first == blackFlag else {
+			return []
+		}
+
+		guard let lastTagIndex = tagIndices.last, scalars[lastTagIndex] == cancelTag else {
+			return []
+		}
+
+		let nonCancelTagCount = tagIndices.count - 1
+		guard nonCancelTagCount > 0, nonCancelTagCount <= maximumAllowedTagScalars else {
+			return []
+		}
+
+		for index in tagIndices.dropLast() {
+			if !isAllowedSubdivisionTag(scalars[index]) {
+				return []
+			}
+		}
+
+		return Set(tagIndices)
+	}
+
+	private static func isCombiningMark(_ scalar: UnicodeScalar) -> Bool {
+		CharacterSet.nonBaseCharacters.contains(scalar)
+	}
+
+	private static func isVariationSelector(_ scalar: UnicodeScalar) -> Bool {
+		(0xFE00...0xFE0F).contains(scalar.value) || (0xE0100...0xE01EF).contains(scalar.value)
+	}
+
+	private static func isBidiOverride(_ scalar: UnicodeScalar) -> Bool {
+		(0x202A...0x202E).contains(scalar.value) || (0x2066...0x2069).contains(scalar.value)
+	}
+
+	private static func isTagScalar(_ scalar: UnicodeScalar) -> Bool {
+		(0xE0001...0xE007F).contains(scalar.value)
+	}
+
+	private static func isAllowedSubdivisionTag(_ scalar: UnicodeScalar) -> Bool {
+		(0xE0030...0xE0039).contains(scalar.value) || (0xE0061...0xE007A).contains(scalar.value)
+	}
+}
+
+public extension String {
+	func sanitizedForExtraction() -> UnicodeSanitizationResult {
+		UnicodeAbuseSanitizer.sanitize(self)
+	}
+}

--- a/Tests/SwiftTextCoreTests/UnicodeAbuseSanitizerTests.swift
+++ b/Tests/SwiftTextCoreTests/UnicodeAbuseSanitizerTests.swift
@@ -1,0 +1,36 @@
+import Foundation
+import SwiftTextCore
+import Testing
+
+struct UnicodeAbuseSanitizerTests {
+	@Test
+	func stripsBidirectionalOverridesAndInvalidTags() {
+		let source = "safe\u{202E}text\u{202C}\u{E0061}\u{E007F}"
+		let result = UnicodeAbuseSanitizer.sanitize(source)
+
+		#expect(result.text == "safetext")
+		#expect(result.report.hasBidiOverrides)
+		#expect(result.report.hasTagAbuse)
+		#expect(result.report.containsAbuse)
+	}
+
+	@Test
+	func trimsCombiningMarkBombs() {
+		let marks = String(repeating: "\u{0301}", count: 20)
+		let source = "A\(marks)"
+		let result = UnicodeAbuseSanitizer.sanitize(source)
+
+		#expect(result.text.unicodeScalars.count == 15)
+		#expect(result.report.excessiveCombiningMarks == 2)
+		#expect(result.report.containsAbuse)
+	}
+
+	@Test
+	func preservesLegitimateEmojiZWJSequences() {
+		let source = "Family: 👨‍👩‍👧‍👦"
+		let result = UnicodeAbuseSanitizer.sanitize(source)
+
+		#expect(result.text == source)
+		#expect(!result.report.containsAbuse)
+	}
+}

--- a/Tests/SwiftTextCoreTests/UnicodeAbuseSanitizerTests.swift
+++ b/Tests/SwiftTextCoreTests/UnicodeAbuseSanitizerTests.swift
@@ -33,4 +33,21 @@ struct UnicodeAbuseSanitizerTests {
 		#expect(result.text == source)
 		#expect(!result.report.containsAbuse)
 	}
+
+	@Test
+	func preservesVariationSelectorsInValidEmojiZWJSequences() {
+		let source = "Comment: 👁️‍🗨️"
+		let result = UnicodeAbuseSanitizer.sanitize(source)
+
+		#expect(result.text == source)
+		#expect(!result.report.containsAbuse)
+	}
+
+	@Test
+	func trimsRepeatedVariationSelectorSpam() {
+		let source = "Alert: ⚠️\u{FE0F}\u{FE0F}"
+		let result = UnicodeAbuseSanitizer.sanitize(source)
+
+		#expect(result.text == "Alert: ⚠️")
+	}
 }

--- a/Tests/SwiftTextHTMLTests/HTMLDocumentTests.swift
+++ b/Tests/SwiftTextHTMLTests/HTMLDocumentTests.swift
@@ -2,6 +2,7 @@ import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
+import SwiftTextCore
 import SwiftTextHTML
 import Testing
 
@@ -28,6 +29,25 @@ func markdownResolvesRelativeImageURLsAgainstBaseURL() async throws {
 	let document = try await HTMLDocument(data: Data(html.utf8), baseURL: baseURL)
 	let markdown = document.markdown()
 	#expect(markdown.contains("![Calendar](https://github.com/mattt/iMCP/raw/main/Assets/calendar.svg)"))
+}
+
+@Test
+func extractedHTMLTextCanBeSanitizedExplicitly() async throws {
+	let html = """
+	<html>
+	<body>
+		<p>Hello\u{202E} there\u{202C}</p>
+	</body>
+	</html>
+	"""
+	let document = try await HTMLDocument(data: Data(html.utf8))
+
+	let rawText = document.text()
+	let sanitization = UnicodeAbuseSanitizer.sanitize(rawText)
+
+	#expect(rawText.contains("\u{202E}"))
+	#expect(sanitization.text == "Hello there")
+	#expect(sanitization.report.hasBidiOverrides)
 }
 
 #if os(macOS)


### PR DESCRIPTION
## Summary
- add a shared Unicode abuse sanitizer for grapheme cluster bombs, bidi overrides, invalid tag sequences, and variation-selector spam
- apply sanitization across HTML, DOCX, PDF/OCR text output, and structured OCR blocks so extracted text is cleaned at the boundary
- add focused Swift Testing coverage for the sanitizer plus HTML and OCR integration paths

Closes #10

## Testing
- swift test --scratch-path /tmp/swifttext-issue10-build --filter "SwiftText(CoreTests|HTMLTests|OCRTests)"