### PR TITLE
Fix image alt-text extraction for nested inline formatting

### DIFF
--- a/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
+++ b/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Markdown
+import SwiftTextMarkdown
 
 /// Builds `DocxWriter.Block` and `DocxWriter.Run` values from a swift-markdown
 /// AST. Internal helper for `MarkdownToDocx`.
@@ -75,8 +76,11 @@ private struct RunCollector {
 			}
 		case let image as Image:
 			// Legacy renderer emitted images as italic placeholder text. Keep
-			// that behavior — DOCX writer doesn't yet inline images.
-			let alt = image.children.compactMap { ($0 as? Text)?.string }.joined()
+			// that behavior — DOCX writer doesn't yet inline images. Walk all
+			// descendants so alt text from nested inline formatting is
+			// preserved (e.g. `![*logo*](...)` keeps "logo" instead of
+			// falling through to the `[image]` placeholder).
+			let alt = reverseSmartPunct(swiftMarkdownPlainText(of: image))
 			let display = alt.isEmpty ? "[image]" : alt
 			runs.append(DocxWriter.Run(text: display, italic: true))
 		case let inlineHTML as InlineHTML:

--- a/Sources/SwiftTextMarkdown/PlainTextExtraction.swift
+++ b/Sources/SwiftTextMarkdown/PlainTextExtraction.swift
@@ -1,0 +1,33 @@
+import Markdown
+
+/// Returns the concatenated plain-text content of an inline container, including
+/// the text inside any nested formatting (`*emphasis*`, `**strong**`, `[links]`,
+/// `~~strike~~`, `` `code` ``, soft/hard breaks, etc.).
+///
+/// Used for things like image `alt` attributes where a single string is wanted
+/// regardless of how the source decorated the description. Direct-children-only
+/// approaches (`children.compactMap { $0 as? Text }`) drop everything inside
+/// nested inline containers and produce empty alt for inputs like
+/// `![*diagram*](img.png)` or `![link [label]](...)`.
+public func swiftMarkdownPlainText(of inlineContainer: Markup) -> String {
+	var result = ""
+	walkInlineForPlainText(inlineContainer, into: &result)
+	return result
+}
+
+private func walkInlineForPlainText(_ markup: Markup, into result: inout String) {
+	switch markup {
+	case let text as Text:
+		result += text.string
+	case let code as InlineCode:
+		result += code.code
+	case is SoftBreak, is LineBreak:
+		result += " "
+	case let html as InlineHTML:
+		result += html.rawHTML
+	default:
+		for child in markup.children {
+			walkInlineForPlainText(child, into: &result)
+		}
+	}
+}

--- a/Sources/SwiftTextMarkdown/SwiftMarkdownHTMLRenderer.swift
+++ b/Sources/SwiftTextMarkdown/SwiftMarkdownHTMLRenderer.swift
@@ -119,10 +119,10 @@ private struct HTMLRenderer: MarkupVisitor {
 
 	mutating func visitImage(_ image: Image) {
 		let src = image.source ?? ""
-		var alt = ""
-		for child in image.children {
-			if let text = child as? Text { alt += text.string }
-		}
+		// Walk all descendants so alt text from nested inline formatting
+		// (e.g. `![*diagram*](img.png)` or `![link [label]](...)`) is
+		// preserved rather than silently dropped.
+		let alt = reverseSmartPunctuation(swiftMarkdownPlainText(of: image))
 		output += "<img src=\"\(escapeAttribute(src))\" alt=\"\(escapeAttribute(alt))\">"
 	}
 

--- a/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
@@ -137,4 +137,20 @@ struct DocxWriterTests {
 			#expect(Bool(false), "Expected blockquote")
 		}
 	}
+
+	@Test("Inline parser keeps formatted alt text on images")
+	func inlineParserImageAltText() {
+		// Regression for PR #16 review: alt text wrapped in emphasis was
+		// dropped, leaving only the `[image]` placeholder.
+		let runs = MarkdownToDocx.parseInline("Caption: ![*logo*](https://x/logo.png) here")
+		let imageRun = runs.first(where: { $0.text == "logo" })
+		#expect(imageRun != nil, "Expected the image's emphasized alt text to survive as a run")
+		#expect(imageRun?.italic == true, "Image runs continue to render as italic placeholders")
+	}
+
+	@Test("Inline parser preserves multi-segment image alt text")
+	func inlineParserImageAltMultiSegment() {
+		let runs = MarkdownToDocx.parseInline("![alt **bold** more](https://x.png)")
+		#expect(runs.contains(where: { $0.text == "alt bold more" }))
+	}
 }

--- a/Tests/SwiftTextHTMLTests/ImageAltTextTests.swift
+++ b/Tests/SwiftTextHTMLTests/ImageAltTextTests.swift
@@ -1,0 +1,36 @@
+import Testing
+@testable import SwiftTextHTML
+
+/// Regression tests for image alt-text extraction when the alt content contains
+/// nested inline formatting (PR #16 review).
+@Suite("Image alt text")
+struct ImageAltTextTests {
+
+	@Test func emphasizedAltTextSurvivesAsPlainText() {
+		let html = MarkdownToHTML.convert("![*diagram*](img.png)")
+		// The alt attribute carries the plain-text rendering of the description,
+		// so emphasis markup is unwrapped rather than dropping the inner text.
+		#expect(html.contains(#"alt="diagram""#))
+		#expect(html.contains(#"src="img.png""#))
+	}
+
+	@Test func strongAltTextSurvives() {
+		let html = MarkdownToHTML.convert("![**important**](img.png)")
+		#expect(html.contains(#"alt="important""#))
+	}
+
+	@Test func mixedFormattingAltText() {
+		let html = MarkdownToHTML.convert("![*part one* part two `code`](img.png)")
+		#expect(html.contains(#"alt="part one part two code""#))
+	}
+
+	@Test func plainAltTextStillWorks() {
+		let html = MarkdownToHTML.convert("![Alt text](img.png)")
+		#expect(html.contains(#"alt="Alt text""#))
+	}
+
+	@Test func emptyAltText() {
+		let html = MarkdownToHTML.convert("![](img.png)")
+		#expect(html.contains(#"alt="""#))
+	}
+}


### PR DESCRIPTION
Addresses two review comments on #16 (both [P2 from codex-connector](https://github.com/Cocoanetics/SwiftText/pull/16#discussion_r0)):

1. `Sources/SwiftTextMarkdown/SwiftMarkdownHTMLRenderer.swift:124` — _Flatten image alt text before writing HTML_
2. `Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift:79` — _Preserve nested image alt text in DOCX run generation_

## Bug

Both renderers collected alt text via `image.children.compactMap { (\$0 as? Text)?.string }`. That only catches **direct** `Text` children, so anything wrapped in inline formatting silently disappeared:

| input | HTML before | HTML after |
|---|---|---|
| `![*diagram*](img.png)` | `<img src=\"img.png\" alt=\"\">` | `<img src=\"img.png\" alt=\"diagram\">` |
| `![**logo**](logo.png)` | `<img src=\"logo.png\" alt=\"\">` | `<img src=\"logo.png\" alt=\"logo\">` |
| `![*part one* part two \`code\`](img.png)` | `<img src=\"img.png\" alt=\" part two \">` | `<img src=\"img.png\" alt=\"part one part two code\">` |

For DOCX, the empty alt fell through to the `[image]` placeholder, losing user-provided descriptions.

## Fix

New shared helper `swiftMarkdownPlainText(of:)` in `SwiftTextMarkdown` that walks every descendant and concatenates `Text` + `InlineCode` content (breaks → spaces; inline HTML kept verbatim). Both renderers use it and apply the same smart-punctuation reversal they apply to regular text.

## Test plan

- [x] 5 new HTML cases in `ImageAltTextTests` — emphasis, strong, mixed formatting, plain, empty
- [x] 2 new DOCX cases — emphasized alt, multi-segment formatted alt
- [x] All 117 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)