### PR TITLE
Trait-guard ArgumentParser and ZIPFoundation so trait-specifying consumers prune them

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -166,9 +166,11 @@ let packageTargets: [Target] = [
 		name: "SwiftTextDOCX",
 		dependencies: [
 			"SwiftTextMarkdown",
-			// "CLI" included because SwiftTextCLI depends on this target, so building
-			// the CLI requires ZIPFoundation even when the DOCX trait is disabled.
-			.product(name: "ZIPFoundation", package: "ZIPFoundation", condition: .when(traits: ["DOCX", "CLI"])),
+			// Single-trait condition on purpose: Swift 6.2's SwiftPM requires ALL listed
+			// traits to be enabled (6.3 changed this to any-of), so an OR-set like
+			// ["DOCX", "CLI"] would drop ZIPFoundation on 6.2 toolchains. The CLI case
+			// is covered by the CLI trait transitively enabling DOCX instead.
+			.product(name: "ZIPFoundation", package: "ZIPFoundation", condition: .when(traits: ["DOCX"])),
 		],
 		path: "Sources/SwiftTextDOCX"
 	),
@@ -201,7 +203,9 @@ let package = Package(
 		.trait(name: "HTML", description: "HTML parsing"),
 		.trait(name: "PDF", description: "PDF text extraction", enabledTraits: ["OCR"]),
 		.trait(name: "DOCX", description: "DOCX extraction"),
-		.trait(name: "CLI", description: "swifttext command-line tool dependencies"),
+		// CLI enables DOCX because SwiftTextCLI links SwiftTextDOCX, whose ZIPFoundation
+		// dependency is guarded by the DOCX trait.
+		.trait(name: "CLI", description: "swifttext command-line tool dependencies", enabledTraits: ["DOCX"]),
 		// "CLI" must be a default trait: the SwiftTextCLI and SwiftTextDOCX targets are
 		// always part of the manifest, so a plain `swift build` needs their external
 		// products (ArgumentParser, ZIPFoundation) active to compile. Consumers that

--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let macOSTargets: [Target] = [
 			"SwiftTextOCR",
 			"SwiftTextPDF",
 			"SwiftTextDOCX",
-			.product(name: "ArgumentParser", package: "swift-argument-parser"),
+			.product(name: "ArgumentParser", package: "swift-argument-parser", condition: .when(traits: ["CLI"])),
 		],
 		path: "Sources/SwiftTextCLI",
 		plugins: [
@@ -166,7 +166,9 @@ let packageTargets: [Target] = [
 		name: "SwiftTextDOCX",
 		dependencies: [
 			"SwiftTextMarkdown",
-			.product(name: "ZIPFoundation", package: "ZIPFoundation"),
+			// "CLI" included because SwiftTextCLI depends on this target, so building
+			// the CLI requires ZIPFoundation even when the DOCX trait is disabled.
+			.product(name: "ZIPFoundation", package: "ZIPFoundation", condition: .when(traits: ["DOCX", "CLI"])),
 		],
 		path: "Sources/SwiftTextDOCX"
 	),
@@ -199,7 +201,13 @@ let package = Package(
 		.trait(name: "HTML", description: "HTML parsing"),
 		.trait(name: "PDF", description: "PDF text extraction", enabledTraits: ["OCR"]),
 		.trait(name: "DOCX", description: "DOCX extraction"),
-		.default(enabledTraits: ["OCR"]),
+		.trait(name: "CLI", description: "swifttext command-line tool dependencies"),
+		// "CLI" must be a default trait: the SwiftTextCLI and SwiftTextDOCX targets are
+		// always part of the manifest, so a plain `swift build` needs their external
+		// products (ArgumentParser, ZIPFoundation) active to compile. Consumers that
+		// specify explicit traits (e.g. ["HTML"]) drop the defaults, which lets SwiftPM
+		// prune both packages from their dependency resolution.
+		.default(enabledTraits: ["OCR", "CLI"]),
 	],
 	dependencies: [
 		.package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),

--- a/README.md
+++ b/README.md
@@ -91,11 +91,13 @@ Umbrella module (single import), with traits:
 )
 ```
 
-SwiftText defaults to `OCR` only. Enable traits as needed:
+SwiftText defaults to `OCR` plus `CLI` (the dependencies of the bundled `swifttext` tool). Enable traits as needed:
 
 ```swift
 traits: [.defaults, "HTML", "PDF", "DOCX"]
 ```
+
+Listing traits explicitly (without `.defaults`) keeps dependency resolution lean: SwiftPM only fetches the packages the enabled traits actually need. For example, `traits: ["HTML"]` resolves just swift-markdown — neither swift-argument-parser nor ZIPFoundation is fetched or pinned.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Umbrella module (single import), with traits:
 )
 ```
 
-SwiftText defaults to `OCR` plus `CLI` (the dependencies of the bundled `swifttext` tool). Enable traits as needed:
+SwiftText defaults to `OCR` plus `CLI` (the dependencies of the bundled `swifttext` tool; `CLI` also enables `DOCX`). Enable traits as needed:
 
 ```swift
 traits: [.defaults, "HTML", "PDF", "DOCX"]


### PR DESCRIPTION
Fixes #19

## Problem

A consumer depending on SwiftText with only `traits: ["HTML"]` (e.g. DTCoreText) still resolved and pinned **swift-argument-parser** and **ZIPFoundation**, because `SwiftTextCLI` and `SwiftTextDOCX` referenced those products without trait conditions — so SwiftPM's SE-0450 trait-based dependency pruning never applied.

## Fix

- New `CLI` trait that transitively enables `DOCX` (the CLI ships DOCX extraction, so building it needs ZIPFoundation).
- The `ArgumentParser` product reference is now `.when(traits: ["CLI"])`.
- The `ZIPFoundation` product reference is now `.when(traits: ["DOCX"])`.
- Default traits are now `["OCR", "CLI"]`, so a plain `swift build` keeps compiling the always-present `SwiftTextCLI`/`SwiftTextDOCX` targets, and default-trait consumers resolve exactly the same packages as before. Consumers that specify explicit traits drop the defaults, which is what activates the pruning.

All conditions deliberately list a **single** trait: Swift 6.2's SwiftPM evaluates multi-trait conditions with all-of semantics ([`allSatisfy`](https://github.com/swiftlang/swift-package-manager/blob/swift-6.2-RELEASE/Sources/PackageModel/Manifest/Manifest%2BTraits.swift#L452)) while 6.3 changed this to any-of ([`contains(where:)`](https://github.com/swiftlang/swift-package-manager/blob/release/6.3/Sources/PackageModel/Manifest/Manifest%2BTraits.swift#L423)). Single-trait conditions behave identically under both, and the OR ("DOCX or CLI") is expressed through the trait hierarchy instead, which both toolchains resolve via the transitive trait closure. (The first revision of this PR used `.when(traits: ["DOCX", "CLI"])`, which broke the macOS/iOS CI jobs on Xcode 26.0 with `no such module 'ZIPFoundation'`.)

## Behavior change

The default trait set now transitively includes `DOCX`, so the umbrella `SwiftText` module re-exports `SwiftTextDOCX` by default (it conditionally `@_exported import`s based on trait compilation conditions). This is additive for default consumers and consistent with ZIPFoundation already being part of their resolution. A consumer that uses the `SwiftTextDOCX` product with *explicit* traits must now include `"DOCX"` in them.

## Verification (macOS, Swift 6.3 + CI on Xcode 26.0 / Linux 6.3 jammy)

Scratch consumer package resolution against this branch:

| Consumer traits | swift-argument-parser | zipfoundation | swift-markdown | builds |
|---|---|---|---|---|
| `["HTML"]` | pruned | pruned | pinned | ✅ (and runs) |
| `["DOCX"]` | pruned | pinned | pinned | ✅ (and runs) |
| none (defaults) | pinned (status quo) | pinned (status quo) | pinned | ✅ `import SwiftText` exposes `DocxDocument` |

- `swift build` with default traits: ✅ (links `swifttext`)
- `swift test` with default traits: ✅ 117 tests pass
- `swift run swifttext --version`: ✅ 1.1.9
- `Package.resolved` of SwiftText itself: unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)