### PR TITLE
Add raw-HTML pass-through option and complete footnote rendering

### DIFF
--- a/Sources/SwiftTextHTML/MarkdownToHTML.swift
+++ b/Sources/SwiftTextHTML/MarkdownToHTML.swift
@@ -19,15 +19,21 @@ public enum MarkdownToHTML {
 
 	// MARK: - Public API
 
+	/// Rendering options, re-exported from ``SwiftMarkdownHTMLRenderer/Options``.
+	///
+	/// Pass ``SwiftMarkdownHTMLRenderer/Options/passThroughRawHTML`` to emit raw
+	/// HTML embedded in the Markdown verbatim instead of escaping it.
+	public typealias Options = SwiftMarkdownHTMLRenderer.Options
+
 	/// Converts a Markdown string to an HTML fragment.
 	///
 	/// Inputs that don't use the `[^id]` / `[^id]: …` footnote syntax round-trip
 	/// through swift-markdown's renderer unchanged — the footnote layer's fast
-	/// path skips straight to ``SwiftMarkdownHTMLRenderer/convert(_:)``. Inputs
-	/// that do use it get definitions extracted, references rewritten in the
-	/// AST, and a `<div class="footnote-definition">` block appended.
-	public static func convert(_ markdown: String) -> String {
-		MarkdownFootnoteRenderer.convert(markdown)
+	/// path skips straight to ``SwiftMarkdownHTMLRenderer/convert(_:options:)``.
+	/// Inputs that do use it get definitions extracted, references rewritten in
+	/// the AST, and a `<div class="footnote-definition">` block appended.
+	public static func convert(_ markdown: String, options: Options = []) -> String {
+		MarkdownFootnoteRenderer.convert(markdown, options: options)
 	}
 
 	/// Default stylesheet for Markdown HTML output.
@@ -90,6 +96,12 @@ public enum MarkdownToHTML {
 	del { color: #777; }
 	li.task-list-item { list-style: none; margin-left: -1.2em; }
 	li.task-list-item input[type="checkbox"] { margin-right: 0.4em; vertical-align: middle; }
+	sup a { text-decoration: none; }
+	.footnote-definition {
+	    margin: 0.8em 0;
+	    font-size: 0.95em;
+	}
+	.footnote-definition p { margin: 0.4em 0; }
 	"""
 
 	/// Converts a Markdown string to a complete HTML document.
@@ -100,9 +112,12 @@ public enum MarkdownToHTML {
 	/// - Parameters:
 	///   - markdown: The Markdown source text.
 	///   - stylesheet: CSS to include in a `<style>` tag. Defaults to ``defaultStylesheet``.
+	///   - options: Rendering options forwarded to ``convert(_:options:)``.
 	/// - Returns: A complete HTML document string.
-	public static func document(_ markdown: String, stylesheet: String? = nil) -> String {
-		let body = convert(markdown)
+	public static func document(
+		_ markdown: String, stylesheet: String? = nil, options: Options = []
+	) -> String {
+		let body = convert(markdown, options: options)
 		let css = stylesheet ?? defaultStylesheet
 		return """
 		<!DOCTYPE html>

--- a/Sources/SwiftTextMarkdown/MarkdownFootnoteRenderer.swift
+++ b/Sources/SwiftTextMarkdown/MarkdownFootnoteRenderer.swift
@@ -27,12 +27,14 @@ public enum MarkdownFootnoteRenderer {
 
 	/// Converts Markdown to an HTML fragment, expanding `[^id]` footnote
 	/// references and `[^id]: …` definition blocks.
-	public static func convert(_ markdown: String) -> String {
+	public static func convert(
+		_ markdown: String, options: SwiftMarkdownHTMLRenderer.Options = []
+	) -> String {
 		let (cleaned, definitions) = extractDefinitions(from: markdown)
 
 		// Fast path: no definitions at all -> nothing to rewrite, render directly.
 		if definitions.isEmpty {
-			return SwiftMarkdownHTMLRenderer.convert(cleaned)
+			return SwiftMarkdownHTMLRenderer.convert(cleaned, options: options)
 		}
 
 		let state = FootnoteState(definitionIDs: definitions.map { $0.id })
@@ -41,20 +43,31 @@ public enum MarkdownFootnoteRenderer {
 		let bodyDocument = Document(parsing: cleaned, options: [])
 		var bodyRewriter = FootnoteReferenceRewriter(state: state)
 		let rewrittenBody = bodyRewriter.visit(bodyDocument) as? Document ?? bodyDocument
-		let bodyHTML = SwiftMarkdownHTMLRenderer.convert(document: rewrittenBody)
+		let bodyHTML = SwiftMarkdownHTMLRenderer.convert(document: rewrittenBody, options: options)
 
 		// Render each definition body, rewriting nested references too.
+		// Rendering a definition can assign a number to a definition that was
+		// only ever referenced from another definition's body — and that other
+		// definition may appear earlier in the source. Re-scan until no pass
+		// renders anything new so such chains resolve regardless of source order.
 		var renderedDefinitions: [(number: Int, html: String)] = []
-		for definition in definitions {
-			guard let number = state.number(forID: definition.id) else {
-				// Definition was never referenced — skip it entirely.
-				continue
+		var renderedIDs = Set<String>()
+		var renderedNewDefinition = true
+		while renderedNewDefinition {
+			renderedNewDefinition = false
+			for definition in definitions where !renderedIDs.contains(definition.id) {
+				guard let number = state.number(forID: definition.id) else {
+					// Definition not referenced (yet) — skip it.
+					continue
+				}
+				let defDocument = Document(parsing: definition.body, options: [])
+				var defRewriter = FootnoteReferenceRewriter(state: state)
+				let rewrittenDef = defRewriter.visit(defDocument) as? Document ?? defDocument
+				let defBodyHTML = SwiftMarkdownHTMLRenderer.convert(document: rewrittenDef, options: options)
+				renderedDefinitions.append((number, defBodyHTML))
+				renderedIDs.insert(definition.id)
+				renderedNewDefinition = true
 			}
-			let defDocument = Document(parsing: definition.body, options: [])
-			var defRewriter = FootnoteReferenceRewriter(state: state)
-			let rewrittenDef = defRewriter.visit(defDocument) as? Document ?? defDocument
-			let defBodyHTML = SwiftMarkdownHTMLRenderer.convert(document: rewrittenDef)
-			renderedDefinitions.append((number, defBodyHTML))
 		}
 
 		// Two-pass sentinel expansion so nested refs inside definition bodies

--- a/Sources/SwiftTextMarkdown/SwiftMarkdownHTMLRenderer.swift
+++ b/Sources/SwiftTextMarkdown/SwiftMarkdownHTMLRenderer.swift
@@ -23,16 +23,30 @@ import Markdown
 /// - Output is the inline HTML fragment — no `<html>`/`<body>` wrapper.
 public enum SwiftMarkdownHTMLRenderer {
 
-	public static func convert(_ markdown: String) -> String {
+	/// Rendering options.
+	public struct Options: OptionSet, Sendable {
+		public let rawValue: Int
+		public init(rawValue: Int) { self.rawValue = rawValue }
+
+		/// Emits raw HTML (inline and block) verbatim instead of escaping it.
+		///
+		/// GitHub-rendered Markdown — READMEs, release notes, comments —
+		/// routinely embeds HTML like `<p align="center"><img …></p>` or
+		/// `<details>`. cmark calls this mode "unsafe": only use it when the
+		/// output is sanitized or displayed without script execution.
+		public static let passThroughRawHTML = Options(rawValue: 1 << 0)
+	}
+
+	public static func convert(_ markdown: String, options: Options = []) -> String {
 		let document = Document(parsing: markdown, options: [])
-		return convert(document: document)
+		return convert(document: document, options: options)
 	}
 
 	/// Renders an already-parsed `Document` to the same HTML fragment shape as
 	/// ``convert(_:)``. Use this entry point when you need to rewrite the AST
 	/// (e.g. with a `MarkupRewriter`) before rendering.
-	public static func convert(document: Document) -> String {
-		var renderer = HTMLRenderer()
+	public static func convert(document: Document, options: Options = []) -> String {
+		var renderer = HTMLRenderer(options: options)
 		renderer.visit(document)
 		return renderer.flush()
 	}
@@ -40,6 +54,12 @@ public enum SwiftMarkdownHTMLRenderer {
 
 private struct HTMLRenderer: MarkupVisitor {
 	typealias Result = Void
+
+	let options: SwiftMarkdownHTMLRenderer.Options
+
+	init(options: SwiftMarkdownHTMLRenderer.Options) {
+		self.options = options
+	}
 
 	private var output: String = ""
 	private var alignmentStack: [[Table.ColumnAlignment?]] = []
@@ -107,6 +127,10 @@ private struct HTMLRenderer: MarkupVisitor {
 	}
 
 	mutating func visitInlineHTML(_ inlineHTML: InlineHTML) {
+		if options.contains(.passThroughRawHTML) {
+			output += inlineHTML.rawHTML
+			return
+		}
 		// Legacy parser escapes raw HTML markers literally during inlineFormat
 		// (the `&<>` substitution runs before regex matching). Match that so an
 		// input like `<div>` becomes `&lt;div&gt;` rather than disappearing.
@@ -114,9 +138,13 @@ private struct HTMLRenderer: MarkupVisitor {
 	}
 
 	mutating func visitHTMLBlock(_ htmlBlock: HTMLBlock) {
-		// Same policy as inline HTML — escape and emit literal characters.
 		var raw = htmlBlock.rawHTML
 		while raw.hasSuffix("\n") { raw.removeLast() }
+		if options.contains(.passThroughRawHTML) {
+			output += raw
+			return
+		}
+		// Same policy as inline HTML — escape and emit literal characters.
 		output += escapeHTMLNotQuote(raw)
 	}
 

--- a/Tests/SwiftTextHTMLTests/MarkdownToHTMLTests.swift
+++ b/Tests/SwiftTextHTMLTests/MarkdownToHTMLTests.swift
@@ -134,4 +134,25 @@ struct MarkdownToHTMLTests {
 		#expect(text.contains("bold"))
 		#expect(text.contains("link"))
 	}
+
+	@Test func footnotes() {
+		let html = MarkdownToHTML.convert("Hello[^a].\n\n[^a]: The note")
+		#expect(html.contains("<sup><a href=\"#fn-1\" id=\"ref-1\">[1]</a></sup>"))
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-1\"><strong>[1]:</strong> The note</div>"))
+	}
+
+	@Test func rawHTMLPassThroughOption() {
+		let input = "Press <kbd>K</kbd> to open[^k].\n\n[^k]: A note"
+		#expect(MarkdownToHTML.convert(input).contains("&lt;kbd&gt;K&lt;/kbd&gt;"))
+
+		let html = MarkdownToHTML.convert(input, options: .passThroughRawHTML)
+		#expect(html.contains("Press <kbd>K</kbd> to open"))
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-1\"><strong>[1]:</strong> A note</div>"))
+	}
+
+	@Test func documentForwardsOptions() {
+		let html = MarkdownToHTML.document("press <kbd>K</kbd>", options: .passThroughRawHTML)
+		#expect(html.contains("press <kbd>K</kbd>"))
+		#expect(html.hasPrefix("<!DOCTYPE html>"))
+	}
 }

--- a/Tests/SwiftTextMarkdownTests/MarkdownFootnoteRendererTests.swift
+++ b/Tests/SwiftTextMarkdownTests/MarkdownFootnoteRendererTests.swift
@@ -1,0 +1,114 @@
+import Testing
+@testable import SwiftTextMarkdown
+
+@Suite("MarkdownFootnoteRenderer")
+struct MarkdownFootnoteRendererTests {
+
+	@Test func basicReferenceAndDefinition() {
+		let html = MarkdownFootnoteRenderer.convert("Hello[^a].\n\n[^a]: The note")
+		#expect(html == "<p>Hello<sup><a href=\"#fn-1\" id=\"ref-1\">[1]</a></sup>.</p>\n"
+			+ "<div class=\"footnote-definition\" id=\"fn-1\"><strong>[1]:</strong> The note</div>")
+	}
+
+	@Test func numbersAssignedInOrderOfFirstReference() {
+		let input = "B[^beta] then A[^alpha].\n\n[^alpha]: Alpha note\n[^beta]: Beta note"
+		let html = MarkdownFootnoteRenderer.convert(input)
+		#expect(html.contains("B<sup><a href=\"#fn-1\" id=\"ref-1\">[1]</a></sup>"))
+		#expect(html.contains("A<sup><a href=\"#fn-2\" id=\"ref-2\">[2]</a></sup>"))
+		// Definitions block is ordered by footnote number, not source order.
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-1\"><strong>[1]:</strong> Beta note</div>\n"
+			+ "<div class=\"footnote-definition\" id=\"fn-2\"><strong>[2]:</strong> Alpha note</div>"))
+	}
+
+	@Test func repeatedReferenceGetsUniqueAnchorIDs() {
+		let html = MarkdownFootnoteRenderer.convert("First[^n] and second[^n].\n\n[^n]: Note")
+		#expect(html.contains("<a href=\"#fn-1\" id=\"ref-1\">[1]</a>"))
+		#expect(html.contains("<a href=\"#fn-1\" id=\"ref-1-2\">[1]</a>"))
+	}
+
+	@Test func orphanReferenceStaysLiteral() {
+		// No definitions at all — fast path, nothing substituted.
+		#expect(MarkdownFootnoteRenderer.convert("Hello[^ghost].") == "<p>Hello[^ghost].</p>")
+
+		// Orphan alongside a real footnote — only the real one is substituted.
+		let html = MarkdownFootnoteRenderer.convert("Real[^r] and ghost[^g].\n\n[^r]: exists")
+		#expect(html.contains("ghost[^g]."))
+		#expect(html.contains("Real<sup><a href=\"#fn-1\" id=\"ref-1\">[1]</a></sup>"))
+		#expect(!html.contains("fn-2"))
+	}
+
+	@Test func unreferencedDefinitionIsDropped() {
+		let html = MarkdownFootnoteRenderer.convert("No refs here.\n\n[^unused]: Gone")
+		#expect(html == "<p>No refs here.</p>")
+		#expect(!html.contains("Gone"))
+	}
+
+	@Test func referenceInsideInlineCodeIsNotSubstituted() {
+		let html = MarkdownFootnoteRenderer.convert("Use `[^c]` and real[^c].\n\n[^c]: Code note")
+		#expect(html.contains("<code>[^c]</code>"))
+		#expect(html.contains("real<sup><a href=\"#fn-1\" id=\"ref-1\">[1]</a></sup>"))
+	}
+
+	@Test func definitionWithContinuationLines() {
+		let input = "Text[^long].\n\n[^long]: First line\n    continued line"
+		let html = MarkdownFootnoteRenderer.convert(input)
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-1\">"))
+		#expect(html.contains("First line"))
+		#expect(html.contains("continued line"))
+	}
+
+	@Test func multiParagraphDefinition() {
+		let input = "Text[^m].\n\n[^m]: First para.\n\n    Second para."
+		let html = MarkdownFootnoteRenderer.convert(input)
+		// Multi-block body keeps the label in its own paragraph.
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-1\"><p><strong>[1]:</strong></p>"))
+		#expect(html.contains("<p>First para.</p>"))
+		#expect(html.contains("<p>Second para.</p>"))
+	}
+
+	@Test func nestedReferenceInsideDefinition() {
+		let input = "Main[^a].\n\n[^a]: See also[^b].\n[^b]: Other note."
+		let html = MarkdownFootnoteRenderer.convert(input)
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-1\"><strong>[1]:</strong> See also<sup><a href=\"#fn-2\" id=\"ref-2\">[2]</a></sup>.</div>"))
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-2\"><strong>[2]:</strong> Other note.</div>"))
+	}
+
+	@Test func nestedReferenceToEarlierDefinition() {
+		// [^b] is defined before [^a] in source but only referenced from inside
+		// [^a]'s body — it must still be rendered.
+		let input = "Main[^a].\n\n[^b]: Other note.\n[^a]: See also[^b]."
+		let html = MarkdownFootnoteRenderer.convert(input)
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-1\"><strong>[1]:</strong> See also<sup><a href=\"#fn-2\" id=\"ref-2\">[2]</a></sup>.</div>"))
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-2\"><strong>[2]:</strong> Other note.</div>"))
+	}
+
+	@Test func rawHTMLEscapedByDefaultWithFootnotes() {
+		let input = "Press <kbd>K</kbd> to open[^k].\n\n[^k]: Keyboard note with <sub>html</sub>."
+		let html = MarkdownFootnoteRenderer.convert(input)
+		#expect(html.contains("&lt;kbd&gt;K&lt;/kbd&gt;"))
+		#expect(html.contains("&lt;sub&gt;html&lt;/sub&gt;"))
+		#expect(html.contains("<sup><a href=\"#fn-1\" id=\"ref-1\">[1]</a></sup>"))
+	}
+
+	@Test func passThroughRawHTMLOptionReachesBodyAndDefinitions() {
+		let input = "Press <kbd>K</kbd> to open[^k].\n\n[^k]: Keyboard note with <sub>html</sub>."
+		let html = MarkdownFootnoteRenderer.convert(input, options: .passThroughRawHTML)
+		#expect(html.contains("Press <kbd>K</kbd> to open"))
+		#expect(html.contains("Keyboard note with <sub>html</sub>."))
+		#expect(html.contains("<sup><a href=\"#fn-1\" id=\"ref-1\">[1]</a></sup>"))
+	}
+
+	@Test func passThroughRawHTMLOptionOnFastPath() {
+		// No footnote definitions -> fast path must still forward the options.
+		let html = MarkdownFootnoteRenderer.convert(
+			"<p align=\"center\"><img src=\"logo.png\"></p>", options: .passThroughRawHTML)
+		#expect(html.contains("<p align=\"center\"><img src=\"logo.png\"></p>"))
+	}
+
+	@Test func passThroughRawHTMLBlockAlongsideFootnotes() {
+		let input = "Intro[^1].\n\n<div class=\"x\">raw</div>\n\n[^1]: Note"
+		let html = MarkdownFootnoteRenderer.convert(input, options: .passThroughRawHTML)
+		#expect(html.contains("<div class=\"x\">raw</div>"))
+		#expect(html.contains("<div class=\"footnote-definition\" id=\"fn-1\"><strong>[1]:</strong> Note</div>"))
+	}
+}

--- a/Tests/SwiftTextMarkdownTests/SwiftMarkdownHTMLRendererTests.swift
+++ b/Tests/SwiftTextMarkdownTests/SwiftMarkdownHTMLRendererTests.swift
@@ -147,4 +147,33 @@ struct SwiftMarkdownHTMLRendererTests {
 		#expect(html.contains(#"<li class="task-list-item"><input type="checkbox" disabled> Todo</li>"#))
 		#expect(html.contains(#"<li class="task-list-item"><input type="checkbox" disabled checked> Done</li>"#))
 	}
+
+	@Test func rawHTMLEscapedByDefault() {
+		let block = SwiftMarkdownHTMLRenderer.convert("<p align=\"center\"><img src=\"logo.png\"></p>")
+		#expect(block.contains("&lt;p align=\"center\"&gt;"))
+		#expect(!block.contains("<img"))
+
+		let inline = SwiftMarkdownHTMLRenderer.convert("before <kbd>K</kbd> after")
+		#expect(inline.contains("&lt;kbd&gt;K&lt;/kbd&gt;"))
+	}
+
+	@Test func rawHTMLPassThroughOption() {
+		// block-level raw HTML is emitted verbatim
+		let block = SwiftMarkdownHTMLRenderer.convert(
+			"<p align=\"center\"> <img src=\"Documentation/Logo.png\" alt=\"Logo\" width=\"400\"/> </p>",
+			options: .passThroughRawHTML)
+		#expect(block.contains("<p align=\"center\">"))
+		#expect(block.contains("<img src=\"Documentation/Logo.png\" alt=\"Logo\" width=\"400\"/>"))
+
+		// inline raw HTML inside a paragraph is emitted verbatim too
+		let inline = SwiftMarkdownHTMLRenderer.convert(
+			"press <kbd>K</kbd> to continue", options: .passThroughRawHTML)
+		#expect(inline.contains("press <kbd>K</kbd> to continue"))
+
+		// markdown-level escaping of text is unaffected
+		let mixed = SwiftMarkdownHTMLRenderer.convert(
+			"a < b and <sub>x</sub>", options: .passThroughRawHTML)
+		#expect(mixed.contains("a &lt; b"))
+		#expect(mixed.contains("<sub>x</sub>"))
+	}
 }


### PR DESCRIPTION
## Summary

Completes the in-progress raw-HTML option work (previously uncommitted in the working tree) and closes the remaining gaps in the footnote layer.

- **`SwiftMarkdownHTMLRenderer.Options`** with `.passThroughRawHTML`: emits inline/block raw HTML verbatim instead of escaping it (cmark's "unsafe" mode), for GitHub-style content like `<p align="center"><img …></p>` or `<kbd>`. Default behavior is unchanged — raw HTML is still escaped.
- **`MarkdownFootnoteRenderer.convert`** threads the options through body, definition, and fast-path rendering.
- **`MarkdownToHTML.convert`/`document`** now expose the options (with a `MarkdownToHTML.Options` typealias). Without this, the option was unreachable from the public API — the renderer-level plumbing existed but no public entry point accepted it.
- **`defaultStylesheet`** now styles `sup a` and `.footnote-definition`, matching the PDF command's CSS. `convert()` has emitted footnotes by default since bf494de, but `document()` output left them unstyled.
- **Bug fix:** definition rendering now re-scans until no new definitions render. Previously a single source-order pass dropped any footnote referenced only from another definition's body when it appeared earlier in the source — emitting a dead `#fn-N` anchor with no definition block.

## Test plan

- New `MarkdownFootnoteRendererTests` suite — first coverage for the footnote renderer: exact-output basic case, first-reference numbering, unique anchor ids for repeated refs, orphan refs staying literal, unreferenced definitions dropped, inline-code immunity, continuation lines, multi-paragraph definitions, nested definitions in both source orders (the second exercises the bug fix), and option threading incl. the fast path.
- Public-API tests in `MarkdownToHTMLTests` for footnotes, the pass-through option, and `document()` forwarding.
- Full suite: 136 tests in 10 suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)