### PR TITLE
DOCX: preserve strikethrough formatting

### DIFF
--- a/Sources/SwiftTextDOCX/DocxWriter.swift
+++ b/Sources/SwiftTextDOCX/DocxWriter.swift
@@ -70,13 +70,15 @@ public final class DocxWriter {
 		public var text: String
 		public var bold: Bool
 		public var italic: Bool
+		public var strike: Bool
 		public var code: Bool
 		public var link: String?
 
-		public init(text: String, bold: Bool = false, italic: Bool = false, code: Bool = false, link: String? = nil) {
+		public init(text: String, bold: Bool = false, italic: Bool = false, strike: Bool = false, code: Bool = false, link: String? = nil) {
 			self.text = text
 			self.bold = bold
 			self.italic = italic
+			self.strike = strike
 			self.code = code
 			self.link = link
 		}
@@ -441,11 +443,13 @@ public final class DocxWriter {
 				var rPr = "<w:rStyle w:val=\"Hyperlink\"/>"
 				if run.bold { rPr += "<w:b/><w:bCs/>" }
 				if run.italic { rPr += "<w:i/><w:iCs/>" }
+				if run.strike { rPr += "<w:strike/>" }
 				xml += "<w:hyperlink r:id=\"\(rId)\"><w:r><w:rPr>\(rPr)</w:rPr><w:t xml:space=\"preserve\">\(xmlEscape(run.text))</w:t></w:r></w:hyperlink>"
 			} else {
 				var rPr = ""
 				if run.bold { rPr += "<w:b/><w:bCs/>" }
 				if run.italic { rPr += "<w:i/><w:iCs/>" }
+				if run.strike { rPr += "<w:strike/>" }
 				if run.code {
 					rPr += "<w:rFonts w:ascii=\"Courier New\" w:hAnsi=\"Courier New\" w:cs=\"Courier New\"/>"
 					rPr += "<w:sz w:val=\"21\"/><w:szCs w:val=\"21\"/>"

--- a/Sources/SwiftTextDOCX/DocxWriter.swift
+++ b/Sources/SwiftTextDOCX/DocxWriter.swift
@@ -397,12 +397,11 @@ public final class DocxWriter {
 			xml += "<w:tcW w:w=\"\(colWidth)\" w:type=\"dxa\"/>\n"
 			xml += "<w:shd w:val=\"clear\" w:color=\"auto\" w:fill=\"DCDCDC\"/>\n"  // Header background
 			xml += "</w:tcPr>\n"
-			// Cell paragraph with bold text
+			// Header cells force bold, but should still preserve inline styles
+			// such as strikethrough from the source runs.
 			let align = alignmentXML(for: ci)
 			xml += "<w:p><w:pPr>\(align)</w:pPr>"
-			for run in cellRuns {
-				xml += "<w:r><w:rPr><w:b/><w:bCs/></w:rPr><w:t xml:space=\"preserve\">\(xmlEscape(run.text))</w:t></w:r>"
-			}
+			xml += renderRuns(cellRuns, forceBold: true)
 			xml += "</w:p>\n"
 			xml += "</w:tc>\n"
 		}
@@ -435,19 +434,19 @@ public final class DocxWriter {
 
 	// MARK: - Run Rendering
 
-	private func renderRuns(_ runs: [Run]) -> String {
+	private func renderRuns(_ runs: [Run], forceBold: Bool = false) -> String {
 		var xml = ""
 		for run in runs {
 			if let link = run.link {
 				let rId = nextHyperlinkId(url: link)
 				var rPr = "<w:rStyle w:val=\"Hyperlink\"/>"
-				if run.bold { rPr += "<w:b/><w:bCs/>" }
+				if run.bold || forceBold { rPr += "<w:b/><w:bCs/>" }
 				if run.italic { rPr += "<w:i/><w:iCs/>" }
 				if run.strike { rPr += "<w:strike/>" }
 				xml += "<w:hyperlink r:id=\"\(rId)\"><w:r><w:rPr>\(rPr)</w:rPr><w:t xml:space=\"preserve\">\(xmlEscape(run.text))</w:t></w:r></w:hyperlink>"
 			} else {
 				var rPr = ""
-				if run.bold { rPr += "<w:b/><w:bCs/>" }
+				if run.bold || forceBold { rPr += "<w:b/><w:bCs/>" }
 				if run.italic { rPr += "<w:i/><w:iCs/>" }
 				if run.strike { rPr += "<w:strike/>" }
 				if run.code {

--- a/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
+++ b/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
@@ -33,6 +33,7 @@ enum MarkdownDocxBuilder {
 private struct RunStyle {
 	var bold: Bool = false
 	var italic: Bool = false
+	var strike: Bool = false
 	var code: Bool = false
 	var link: String? = nil
 }
@@ -57,16 +58,16 @@ private struct RunCollector {
 			withStyle({ $0.bold = true }) {
 				$0.collect(from: strong)
 			}
-		case is Strikethrough:
-			// DocxWriter.Run has no strikethrough field today, so we drop the
-			// marker and emit the inner content as a regular styled span. If a
-			// future writer adds support, this is the place to thread it.
-			collect(from: markup)
+		case let strikethrough as Strikethrough:
+			withStyle({ $0.strike = true }) {
+				$0.collect(from: strikethrough)
+			}
 		case let inlineCode as InlineCode:
 			runs.append(DocxWriter.Run(
 				text: inlineCode.code,
 				bold: style.bold,
 				italic: style.italic,
+				strike: style.strike,
 				code: true,
 				link: style.link
 			))
@@ -99,6 +100,7 @@ private struct RunCollector {
 			text: text,
 			bold: style.bold,
 			italic: style.italic,
+			strike: style.strike,
 			code: style.code,
 			link: style.link
 		))

--- a/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
@@ -94,6 +94,30 @@ struct DocxWriterTests {
 		#expect(xml.contains("rLink1"))
 	}
 
+	@Test("Markdown table headers preserve strikethrough")
+	func markdownTableHeaderStrikethrough() throws {
+		let markdown = """
+		| ~~Old~~ | Fresh |
+		| --- | --- |
+		| value | next |
+		"""
+
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("md-table-header-strike-\(UUID().uuidString).docx")
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		try MarkdownToDocx.convert(markdown, to: url)
+
+		let archive = try #require(Archive(url: url, accessMode: .read))
+		var documentData = Data()
+		let entry = try #require(archive["word/document.xml"])
+		_ = try archive.extract(entry) { documentData.append($0) }
+		let xml = String(data: documentData, encoding: .utf8)!
+
+		#expect(xml.contains("Old"))
+		#expect(xml.contains("<w:strike/>"))
+	}
+
 	@Test("Inline parser handles mixed formatting")
 	func inlineParser() {
 		let runs = MarkdownToDocx.parseInline("Hello **bold** and *italic* with `code`")

--- a/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
@@ -53,7 +53,7 @@ struct DocxWriterTests {
 		let markdown = """
 		# Hello World
 
-		This is **bold** and *italic* text with `code`.
+		This is **bold** and *italic* text with ~~strike~~ and `code`.
 
 		- Item A
 		- Item B
@@ -88,6 +88,7 @@ struct DocxWriterTests {
 		#expect(xml.contains("Heading1"))
 		#expect(xml.contains("<w:b/>"))
 		#expect(xml.contains("<w:i/>"))
+		#expect(xml.contains("<w:strike/>"))
 		#expect(xml.contains("Courier New"))
 		#expect(xml.contains("print(&quot;hi&quot;)"))
 		#expect(xml.contains("rLink1"))
@@ -125,6 +126,17 @@ struct DocxWriterTests {
 		#expect(runs[1].text == "important")
 		#expect(runs[1].bold == true)
 		#expect(runs[1].italic == true)
+	}
+
+	@Test("Inline parser handles strikethrough and nested emphasis")
+	func inlineParserStrikethrough() {
+		let runs = MarkdownToDocx.parseInline("A ~~gone~~ and ~~**loud**~~")
+		#expect(runs.count == 4)
+		#expect(runs[1].text == "gone")
+		#expect(runs[1].strike == true)
+		#expect(runs[3].text == "loud")
+		#expect(runs[3].strike == true)
+		#expect(runs[3].bold == true)
 	}
 
 	@Test("Block parser handles nested blockquotes")


### PR DESCRIPTION
## Summary
- preserve strikethrough styling in Markdown -> DOCX conversion
- thread `strike` through `DocxWriter.Run` and emit `<w:strike/>` in OOXML
- add regression coverage for inline parsing and generated DOCX output

## Testing
- `swift test --build-path /tmp/swifttext-docx-build --filter DocxWriterTests/inlineParserStrikethrough`
- `swift test --build-path /tmp/swifttext-docx-build2 --filter DocxWriterTests/markdownConversion`
