### PR TITLE
DOCX: emit native Word footnotes (MD→DOCX), round-tripping the reader

### DIFF
--- a/Sources/SwiftTextDOCX/DocxWriter.swift
+++ b/Sources/SwiftTextDOCX/DocxWriter.swift
@@ -78,14 +78,34 @@ public final class DocxWriter {
 		public var strike: Bool
 		public var code: Bool
 		public var link: String?
+		/// When set, this run is a footnote reference to the footnote with this
+		/// id (see ``Footnote``). The writer emits a `w:footnoteReference` run
+		/// and ignores `text`/styling.
+		public var footnoteRef: Int?
 
-		public init(text: String, bold: Bool = false, italic: Bool = false, strike: Bool = false, code: Bool = false, link: String? = nil) {
+		public init(text: String, bold: Bool = false, italic: Bool = false, strike: Bool = false, code: Bool = false, link: String? = nil, footnoteRef: Int? = nil) {
 			self.text = text
 			self.bold = bold
 			self.italic = italic
 			self.strike = strike
 			self.code = code
 			self.link = link
+			self.footnoteRef = footnoteRef
+		}
+	}
+
+	/// A footnote: its `w:id` (referenced by ``Run/footnoteRef`` runs in the
+	/// body) and its body content, rendered at the bottom of the page by Word.
+	public struct Footnote {
+		/// The footnote's `w:id`. Must be positive (ids `-1`/`0` are reserved
+		/// for the separator/continuationSeparator pseudo-footnotes).
+		public var id: Int
+		/// The footnote body as block content (typically one or more paragraphs).
+		public var blocks: [Block]
+
+		public init(id: Int, blocks: [Block]) {
+			self.id = id
+			self.blocks = blocks
 		}
 	}
 
@@ -93,6 +113,10 @@ public final class DocxWriter {
 
 	/// The blocks to render into the DOCX document.
 	public var blocks: [Block] = []
+
+	/// The document's footnotes. When non-empty, a `word/footnotes.xml` part is
+	/// emitted and registered; body runs reference them via ``Run/footnoteRef``.
+	public var footnotes: [Footnote] = []
 
 	/// Page setup (paper size, margins, orientation). Defaults to A4 portrait.
 	public var pageSetup: DocxPageSetup = .a4
@@ -187,6 +211,10 @@ public final class DocxWriter {
 		// Embedded image media parts (word/media/imageN.ext).
 		for media in mediaFiles {
 			try addEntry(archive, path: media.path, data: media.data)
+		}
+
+		if !footnotes.isEmpty {
+			try addEntry(archive, path: "word/footnotes.xml", content: generateFootnotes())
 		}
 	}
 
@@ -584,6 +612,12 @@ public final class DocxWriter {
 	private func renderRuns(_ runs: [Run], forceBold: Bool = false) -> String {
 		var xml = ""
 		for run in runs {
+			if let number = run.footnoteRef {
+				// Native Word footnote reference: a superscript auto-number that
+				// Word resolves against the matching <w:footnote w:id> body.
+				xml += "<w:r><w:rPr><w:rStyle w:val=\"FootnoteReference\"/></w:rPr><w:footnoteReference w:id=\"\(number)\"/></w:r>"
+				continue
+			}
 			if let link = run.link {
 				let rId = nextHyperlinkId(url: link)
 				var rPr = "<w:rStyle w:val=\"Hyperlink\"/>"
@@ -640,6 +674,10 @@ public final class DocxWriter {
 			.map { "<Default Extension=\"\($0.key)\" ContentType=\"\($0.value)\"/>" }
 			.joined(separator: "\n")
 		let imageDefaultsXML = imageDefaults.isEmpty ? "" : "\n\(imageDefaults)"
+		let footnotesOverride = footnotes.isEmpty ? "" : """
+		<Override PartName="/word/footnotes.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.footnotes+xml"/>
+
+		"""
 		return """
 		<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 		<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
@@ -650,7 +688,7 @@ public final class DocxWriter {
 		<Override PartName="/word/numbering.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.numbering+xml"/>
 		<Override PartName="/word/settings.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.settings+xml"/>
 		<Override PartName="/word/fontTable.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.fontTable+xml"/>
-		</Types>
+		\(footnotesOverride)</Types>
 		"""
 	}
 
@@ -673,6 +711,9 @@ public final class DocxWriter {
 		<Relationship Id="rId4" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/fontTable" Target="fontTable.xml"/>
 
 		"""
+		if !footnotes.isEmpty {
+			rels += "<Relationship Id=\"rId5\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/footnotes\" Target=\"footnotes.xml\"/>\n"
+		}
 		for link in hyperlinks {
 			rels += "<Relationship Id=\"\(link.id)\" Type=\"http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink\" Target=\"\(xmlEscape(link.url))\" TargetMode=\"External\"/>\n"
 		}
@@ -766,6 +807,24 @@ public final class DocxWriter {
 		<w:rPr>
 		<w:color w:val="0366D6"/>
 		<w:u w:val="single"/>
+		</w:rPr>
+		</w:style>
+
+		<w:style w:type="paragraph" w:styleId="FootnoteText">
+		<w:name w:val="footnote text"/>
+		<w:basedOn w:val="Normal"/>
+		<w:pPr>
+		<w:spacing w:before="0" w:after="0" w:line="240" w:lineRule="auto"/>
+		</w:pPr>
+		<w:rPr>
+		<w:sz w:val="20"/><w:szCs w:val="20"/>
+		</w:rPr>
+		</w:style>
+
+		<w:style w:type="character" w:styleId="FootnoteReference">
+		<w:name w:val="footnote reference"/>
+		<w:rPr>
+		<w:vertAlign w:val="superscript"/>
 		</w:rPr>
 		</w:style>
 
@@ -899,6 +958,107 @@ public final class DocxWriter {
 		</w:font>
 		</w:fonts>
 		"""
+	}
+
+	// MARK: - Footnotes
+
+	private func generateFootnotes() -> String {
+		// Word requires the separator / continuationSeparator pseudo-footnotes at
+		// the reserved ids -1 and 0; it draws the rule above the notes from them.
+		var xml = """
+		<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+		<w:footnotes \
+		xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" \
+		xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+		<w:footnote w:type="separator" w:id="-1"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:separator/></w:r></w:p></w:footnote>
+		<w:footnote w:type="continuationSeparator" w:id="0"><w:p><w:pPr><w:spacing w:after="0" w:line="240" w:lineRule="auto"/></w:pPr><w:r><w:continuationSeparator/></w:r></w:p></w:footnote>
+
+		"""
+		for footnote in footnotes.sorted(by: { $0.id < $1.id }) {
+			xml += "<w:footnote w:id=\"\(footnote.id)\">\n"
+			xml += footnoteBodyXML(footnote.blocks)
+			xml += "</w:footnote>\n"
+		}
+		xml += "</w:footnotes>"
+		return xml
+	}
+
+	/// Renders a footnote body as one or more `FootnoteText` paragraphs. The
+	/// first paragraph carries the auto-numbered reference mark (`w:footnoteRef`).
+	private func footnoteBodyXML(_ blocks: [Block]) -> String {
+		var paragraphs = footnoteRunParagraphs(from: blocks)
+		if paragraphs.isEmpty { paragraphs = [[]] }  // empty note still needs the mark
+
+		var xml = ""
+		for (index, runs) in paragraphs.enumerated() {
+			xml += "<w:p><w:pPr><w:pStyle w:val=\"FootnoteText\"/></w:pPr>"
+			if index == 0 {
+				xml += "<w:r><w:rPr><w:rStyle w:val=\"FootnoteReference\"/></w:rPr><w:footnoteRef/></w:r>"
+				xml += "<w:r><w:t xml:space=\"preserve\"> </w:t></w:r>"
+			}
+			xml += renderFootnoteRuns(runs)
+			xml += "</w:p>\n"
+		}
+		return xml
+	}
+
+	/// Flattens footnote body blocks into a list of paragraphs (each a run list).
+	/// Word footnotes don't carry tables/rules/nested numbering, so those are
+	/// reduced to their inline text; code blocks become one line per paragraph.
+	private func footnoteRunParagraphs(from blocks: [Block]) -> [[Run]] {
+		var paragraphs: [[Run]] = []
+		for block in blocks {
+			switch block {
+			case .paragraph(let runs):
+				paragraphs.append(runs)
+			case .heading(_, let runs):
+				paragraphs.append(runs)
+			case .listItem(_, _, let runs):
+				paragraphs.append(runs)
+			case .blockquote(let inner):
+				paragraphs.append(contentsOf: footnoteRunParagraphs(from: inner))
+			case .codeBlock(_, let text):
+				for line in text.components(separatedBy: "\n") {
+					paragraphs.append([Run(text: line, code: true)])
+				}
+			case .table(let headers, let rows, _):
+				for cell in headers { paragraphs.append(cell) }
+				for row in rows { for cell in row { paragraphs.append(cell) } }
+			case .image(_, let alt):
+				// Word footnotes don't embed pictures here; degrade to the italic
+				// alt-text placeholder, matching the inline-image fallback.
+				paragraphs.append([Run(text: alt, italic: true)])
+			case .horizontalRule:
+				break
+			}
+		}
+		return paragraphs
+	}
+
+	/// Like ``renderRuns(_:)`` but for footnote bodies: never allocates document
+	/// hyperlink relationships (links render as styled text), and a nested
+	/// footnote reference degrades to a superscript `[N]` since Word can't nest
+	/// footnotes.
+	private func renderFootnoteRuns(_ runs: [Run]) -> String {
+		var xml = ""
+		for run in runs {
+			if let number = run.footnoteRef {
+				xml += "<w:r><w:rPr><w:rStyle w:val=\"FootnoteReference\"/></w:rPr><w:t xml:space=\"preserve\">[\(number)]</w:t></w:r>"
+				continue
+			}
+			var rPr = ""
+			if run.link != nil { rPr += "<w:rStyle w:val=\"Hyperlink\"/>" }
+			if run.bold { rPr += "<w:b/><w:bCs/>" }
+			if run.italic { rPr += "<w:i/><w:iCs/>" }
+			if run.strike { rPr += "<w:strike/>" }
+			if run.code {
+				rPr += "<w:rFonts w:ascii=\"Courier New\" w:hAnsi=\"Courier New\" w:cs=\"Courier New\"/>"
+				rPr += "<w:sz w:val=\"21\"/><w:szCs w:val=\"21\"/>"
+			}
+			let rPrXML = rPr.isEmpty ? "" : "<w:rPr>\(rPr)</w:rPr>"
+			xml += "<w:r>\(rPrXML)<w:t xml:space=\"preserve\">\(xmlEscape(run.text))</w:t></w:r>"
+		}
+		return xml
 	}
 
 	// MARK: - Utilities

--- a/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
+++ b/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
@@ -6,9 +6,61 @@ import SwiftTextMarkdown
 /// AST. Internal helper for `MarkdownToDocx`.
 enum MarkdownDocxBuilder {
 
+	/// The document model built from Markdown: body blocks plus any footnotes.
+	struct Build {
+		var blocks: [DocxWriter.Block]
+		var footnotes: [DocxWriter.Footnote]
+	}
+
+	/// Builds body blocks and footnotes from Markdown. `[^id]` references and
+	/// `[^id]: …` definitions are parsed with ``MarkdownFootnoteParser`` (which
+	/// swift-markdown can't do natively) and emitted as native Word footnotes.
+	static func build(from markdown: String) -> Build {
+		let (cleaned, definitions) = MarkdownFootnoteParser.extractDefinitions(from: markdown)
+
+		// Fast path: no footnote definitions -> nothing to resolve.
+		guard !definitions.isEmpty else {
+			return Build(blocks: blocks(from: markdown, resolver: nil), footnotes: [])
+		}
+
+		let resolver = MarkdownFootnoteResolver(definitionIDs: definitions.map(\.id))
+
+		// Body blocks: walking the body in document order assigns footnote
+		// numbers in source order of first reference.
+		let bodyBlocks = blocks(from: cleaned, resolver: resolver)
+
+		// Render each referenced definition's body into footnote blocks. A
+		// definition can be referenced only from inside another definition that
+		// appears earlier in source, so re-scan until a pass renders nothing new.
+		var blocksByNumber: [Int: [DocxWriter.Block]] = [:]
+		var renderedIDs = Set<String>()
+		var renderedNew = true
+		while renderedNew {
+			renderedNew = false
+			for definition in definitions where !renderedIDs.contains(definition.id) {
+				guard let number = resolver.number(forID: definition.id) else {
+					// Definition not referenced (yet) — skip it.
+					continue
+				}
+				blocksByNumber[number] = blocks(from: definition.body, resolver: resolver)
+				renderedIDs.insert(definition.id)
+				renderedNew = true
+			}
+		}
+
+		let footnotes = blocksByNumber
+			.sorted { $0.key < $1.key }
+			.map { DocxWriter.Footnote(id: $0.key, blocks: $0.value) }
+		return Build(blocks: bodyBlocks, footnotes: footnotes)
+	}
+
 	static func blocks(from markdown: String) -> [DocxWriter.Block] {
+		build(from: markdown).blocks
+	}
+
+	private static func blocks(from markdown: String, resolver: MarkdownFootnoteResolver?) -> [DocxWriter.Block] {
 		let document = Document(parsing: markdown, options: [])
-		var visitor = BlockVisitor()
+		var visitor = BlockVisitor(resolver: resolver)
 		visitor.visit(document)
 		return visitor.blocks
 	}
@@ -18,11 +70,11 @@ enum MarkdownDocxBuilder {
 	static func runs(fromInline text: String) -> [DocxWriter.Run] {
 		let document = Document(parsing: text, options: [])
 		guard let firstParagraph = document.child(at: 0) as? Paragraph else { return [] }
-		return runs(from: firstParagraph)
+		return runs(from: firstParagraph, resolver: nil)
 	}
 
-	static func runs(from inlineContainer: Markup) -> [DocxWriter.Run] {
-		var collector = RunCollector()
+	static func runs(from inlineContainer: Markup, resolver: MarkdownFootnoteResolver?) -> [DocxWriter.Run] {
+		var collector = RunCollector(resolver: resolver)
 		collector.collect(from: inlineContainer)
 		return collector.runs
 	}
@@ -41,6 +93,12 @@ private struct RunStyle {
 private struct RunCollector {
 	var runs: [DocxWriter.Run] = []
 	private var style = RunStyle()
+	/// When present, `[^id]` references in `Text` nodes become footnote runs.
+	let resolver: MarkdownFootnoteResolver?
+
+	init(resolver: MarkdownFootnoteResolver?) {
+		self.resolver = resolver
+	}
 
 	mutating func collect(from container: Markup) {
 		for child in container.children { visit(child) }
@@ -49,7 +107,7 @@ private struct RunCollector {
 	private mutating func visit(_ markup: Markup) {
 		switch markup {
 		case let text as Text:
-			append(text: reverseSmartPunct(text.string))
+			appendResolvingFootnotes(in: text.string)
 		case let emphasis as Emphasis:
 			withStyle({ $0.italic = true }) {
 				$0.collect(from: emphasis)
@@ -106,6 +164,24 @@ private struct RunCollector {
 		))
 	}
 
+	/// Appends a plain `Text` node, splitting out any `[^id]` footnote
+	/// references (when a resolver is active) into dedicated footnote-reference
+	/// runs. Without a resolver this is just `append(text:)`.
+	private mutating func appendResolvingFootnotes(in string: String) {
+		guard let resolver else {
+			append(text: reverseSmartPunct(string))
+			return
+		}
+		for segment in resolver.resolve(string) {
+			switch segment {
+			case .text(let value):
+				if !value.isEmpty { append(text: reverseSmartPunct(value)) }
+			case .reference(let number):
+				runs.append(DocxWriter.Run(text: "", footnoteRef: number))
+			}
+		}
+	}
+
 	private mutating func withStyle(_ apply: (inout RunStyle) -> Void, _ body: (inout RunCollector) -> Void) {
 		let saved = style
 		apply(&style)
@@ -121,6 +197,12 @@ private struct BlockVisitor: MarkupVisitor {
 
 	var blocks: [DocxWriter.Block] = []
 	private var listLevel: Int = 0
+	/// Shared across the whole document so footnote numbers stay in source order.
+	let resolver: MarkdownFootnoteResolver?
+
+	init(resolver: MarkdownFootnoteResolver?) {
+		self.resolver = resolver
+	}
 
 	mutating func defaultVisit(_ markup: Markup) {
 		for child in markup.children { visit(child) }
@@ -141,12 +223,12 @@ private struct BlockVisitor: MarkupVisitor {
 			blocks.append(.image(source: source, alt: alt))
 			return
 		}
-		blocks.append(.paragraph(runs: MarkdownDocxBuilder.runs(from: paragraph)))
+		blocks.append(.paragraph(runs: MarkdownDocxBuilder.runs(from: paragraph, resolver: resolver)))
 	}
 
 	mutating func visitHeading(_ heading: Heading) {
 		let level = max(1, min(heading.level, 6))
-		blocks.append(.heading(level: level, runs: MarkdownDocxBuilder.runs(from: heading)))
+		blocks.append(.heading(level: level, runs: MarkdownDocxBuilder.runs(from: heading, resolver: resolver)))
 	}
 
 	mutating func visitCodeBlock(_ codeBlock: CodeBlock) {
@@ -160,7 +242,7 @@ private struct BlockVisitor: MarkupVisitor {
 	}
 
 	mutating func visitBlockQuote(_ blockQuote: BlockQuote) {
-		var inner = BlockVisitor()
+		var inner = BlockVisitor(resolver: resolver)
 		inner.listLevel = listLevel
 		for child in blockQuote.children { inner.visit(child) }
 		blocks.append(.blockquote(blocks: inner.blocks))
@@ -193,7 +275,7 @@ private struct BlockVisitor: MarkupVisitor {
 				nestedLists.append(child)
 			}
 		}
-		let runs = inlineParagraphs.flatMap { MarkdownDocxBuilder.runs(from: $0) }
+		let runs = inlineParagraphs.flatMap { MarkdownDocxBuilder.runs(from: $0, resolver: resolver) }
 		blocks.append(.listItem(ordered: ordered, level: level, runs: runs))
 
 		listLevel = level + 1
@@ -213,13 +295,13 @@ private struct BlockVisitor: MarkupVisitor {
 		}
 		var headers: [[DocxWriter.Run]] = []
 		for cell in table.head.cells {
-			headers.append(MarkdownDocxBuilder.runs(from: cell))
+			headers.append(MarkdownDocxBuilder.runs(from: cell, resolver: resolver))
 		}
 		var rows: [[[DocxWriter.Run]]] = []
 		for row in table.body.rows {
 			var cells: [[DocxWriter.Run]] = []
 			for cell in row.cells {
-				cells.append(MarkdownDocxBuilder.runs(from: cell))
+				cells.append(MarkdownDocxBuilder.runs(from: cell, resolver: resolver))
 			}
 			rows.append(cells)
 		}

--- a/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
+++ b/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
@@ -54,8 +54,14 @@ enum MarkdownDocxBuilder {
 		return Build(blocks: bodyBlocks, footnotes: footnotes)
 	}
 
+	/// Body blocks only — the low-level path behind `MarkdownToDocx.parseBlocks`.
+	/// It can't carry the footnote bodies (it returns only blocks), so `[^id]`
+	/// references and definitions are left as literal text rather than turned into
+	/// footnote-reference runs whose `word/footnotes.xml` part would be lost,
+	/// leaving orphan `w:footnoteReference` ids. Use `build(from:)` (the `convert`
+	/// path) for native footnotes.
 	static func blocks(from markdown: String) -> [DocxWriter.Block] {
-		build(from: markdown).blocks
+		blocks(from: markdown, resolver: nil)
 	}
 
 	private static func blocks(from markdown: String, resolver: MarkdownFootnoteResolver?) -> [DocxWriter.Block] {

--- a/Sources/SwiftTextDOCX/MarkdownToDocx.swift
+++ b/Sources/SwiftTextDOCX/MarkdownToDocx.swift
@@ -17,9 +17,10 @@ public enum MarkdownToDocx {
 	///     (typically the source `.md` file's folder). When `nil`, images fall back to
 	///     alt-text placeholders.
 	public static func convert(_ markdown: String, to url: URL, pageSetup: DocxPageSetup = .a4, baseURL: URL? = nil) throws {
-		let blocks = parseBlocks(markdown)
+		let build = MarkdownDocxBuilder.build(from: markdown)
 		let writer = DocxWriter()
-		writer.blocks = blocks
+		writer.blocks = build.blocks
+		writer.footnotes = build.footnotes
 		writer.pageSetup = pageSetup
 		writer.baseURL = baseURL
 		try writer.write(to: url)

--- a/Sources/SwiftTextDOCX/MarkdownToDocx.swift
+++ b/Sources/SwiftTextDOCX/MarkdownToDocx.swift
@@ -27,6 +27,10 @@ public enum MarkdownToDocx {
 	}
 
 	/// Parses Markdown text into an array of ``DocxWriter/Block`` elements.
+	///
+	/// This returns blocks only, so footnotes can't be represented: `[^id]`
+	/// references and `[^id]: …` definitions are left as literal text. Use
+	/// ``convert(_:to:pageSetup:baseURL:)`` for native Word footnotes.
 	public static func parseBlocks(_ markdown: String) -> [DocxWriter.Block] {
 		MarkdownDocxBuilder.blocks(from: markdown)
 	}

--- a/Sources/SwiftTextMarkdown/MarkdownFootnoteParsing.swift
+++ b/Sources/SwiftTextMarkdown/MarkdownFootnoteParsing.swift
@@ -1,0 +1,334 @@
+import Foundation
+import Markdown
+
+/// Format-agnostic core for the `[^id]` / `[^id]: …` footnote extension that
+/// swift-markdown doesn't parse natively.
+///
+/// Two renderers build on this:
+/// - ``MarkdownFootnoteRenderer`` (Markdown → HTML), which rewrites references
+///   into sentinel strings and expands them after HTML rendering.
+/// - The Markdown → DOCX writer, which walks the AST and splits each `Text`
+///   node into ``MarkdownFootnoteParser/Segment`` values to emit native Word
+///   `w:footnoteReference` runs.
+///
+/// Both share the same definition scanner and source-order numbering so the two
+/// outputs stay consistent.
+public enum MarkdownFootnoteParser {
+
+	/// A `[^id]: …` definition: its identifier and its body as plain Markdown
+	/// (continuation indentation already stripped).
+	public struct Definition: Sendable, Equatable {
+		public let id: String
+		public let body: String
+
+		public init(id: String, body: String) {
+			self.id = id
+			self.body = body
+		}
+	}
+
+	/// One piece of a `Text` node after footnote-reference resolution: either a
+	/// run of literal text or a footnote reference carrying its assigned number.
+	public enum Segment: Sendable, Equatable {
+		case text(String)
+		case reference(Int)
+	}
+
+	/// Scans `source` for `[^id]: …` definition blocks. Returns the source with
+	/// those blocks removed, plus the captured definitions in source order.
+	public static func extractDefinitions(
+		from source: String
+	) -> (cleaned: String, definitions: [Definition]) {
+		let result = extractFootnoteDefinitions(from: source)
+		return (result.cleaned, result.definitions.map { Definition(id: $0.id, body: $0.body) })
+	}
+}
+
+/// Stateful, source-order resolver for footnote references. Feed it the ids of
+/// the extracted definitions, then call ``resolve(_:)`` on each `Text` node's
+/// string in document order — numbers are assigned on first reference, matching
+/// the HTML renderer's numbering.
+///
+/// References whose id has no matching definition (or whose shape is malformed)
+/// are left as literal text, so `InlineCode`/`CodeBlock` content is preserved
+/// automatically: the AST walker never feeds their strings here.
+public final class MarkdownFootnoteResolver {
+	private let state: FootnoteState
+
+	public init(definitionIDs: [String]) {
+		self.state = FootnoteState(definitionIDs: definitionIDs)
+	}
+
+	/// Splits `text` into literal-text and footnote-reference segments,
+	/// recording each matched reference in source order.
+	public func resolve(_ text: String) -> [MarkdownFootnoteParser.Segment] {
+		scanFootnoteReferences(in: text, record: state.recordReference).map { event in
+			switch event {
+			case .literal(let string): return .text(string)
+			case .reference(let number): return .reference(number)
+			}
+		}
+	}
+
+	/// The number assigned to `id`, or `nil` if it was never referenced.
+	public func number(forID id: String) -> Int? {
+		state.number(forID: id)
+	}
+}
+
+// MARK: - Definition extraction
+
+struct FootnoteDefinition {
+	let id: String
+	let body: String
+}
+
+/// Scans source markdown for `[^id]: …` definition blocks. Returns the source
+/// with those blocks removed, plus the captured definitions in source order.
+///
+/// A definition spans the marker line plus any subsequent lines that are either
+/// blank or indented by at least 4 spaces / one tab (the standard GFM rule).
+/// Indentation is stripped from continuation lines so the captured body is plain
+/// Markdown.
+func extractFootnoteDefinitions(
+	from source: String
+) -> (cleaned: String, definitions: [FootnoteDefinition]) {
+	let normalized = source
+		.replacingOccurrences(of: "\r\n", with: "\n")
+		.replacingOccurrences(of: "\r", with: "\n")
+	let lines = normalized.components(separatedBy: "\n")
+
+	var keptLines: [String] = []
+	keptLines.reserveCapacity(lines.count)
+
+	var definitions: [FootnoteDefinition] = []
+	var seenIDs = Set<String>()
+
+	var i = 0
+	while i < lines.count {
+		let line = lines[i]
+
+		guard let start = parseDefinitionStart(line) else {
+			keptLines.append(line)
+			i += 1
+			continue
+		}
+
+		// Collect body lines: the inline content after `]:`, plus any
+		// indented/blank continuation lines.
+		var bodyLines: [String] = []
+		if !start.firstLineContent.isEmpty {
+			bodyLines.append(start.firstLineContent)
+		}
+
+		var j = i + 1
+		while j < lines.count {
+			let next = lines[j]
+			if next.trimmingCharacters(in: .whitespaces).isEmpty {
+				// Look ahead: if the next non-blank line is also indented, the
+				// blank line is part of the definition (paragraph break inside);
+				// otherwise it terminates the definition.
+				var lookahead = j + 1
+				while lookahead < lines.count && lines[lookahead].trimmingCharacters(in: .whitespaces).isEmpty {
+					lookahead += 1
+				}
+				if lookahead < lines.count, stripContinuationIndent(lines[lookahead]) != nil {
+					bodyLines.append("")
+					j += 1
+					continue
+				}
+				break
+			}
+			if let stripped = stripContinuationIndent(next) {
+				bodyLines.append(stripped)
+				j += 1
+				continue
+			}
+			break
+		}
+
+		// Skip duplicate definitions — first wins.
+		if !seenIDs.contains(start.id) {
+			definitions.append(FootnoteDefinition(id: start.id, body: bodyLines.joined(separator: "\n")))
+			seenIDs.insert(start.id)
+		}
+
+		i = j
+	}
+
+	return (keptLines.joined(separator: "\n"), definitions)
+}
+
+private func parseDefinitionStart(_ line: String) -> (id: String, firstLineContent: String)? {
+	guard line.hasPrefix("[^"),
+	      let closingBracket = line.firstIndex(of: "]") else { return nil }
+	let identifierStart = line.index(line.startIndex, offsetBy: 2)
+	guard identifierStart < closingBracket else { return nil }
+	let colonIndex = line.index(after: closingBracket)
+	guard colonIndex < line.endIndex, line[colonIndex] == ":" else { return nil }
+
+	let id = String(line[identifierStart..<closingBracket]).trimmingCharacters(in: .whitespaces)
+	guard !id.isEmpty else { return nil }
+
+	let contentStart = line.index(after: colonIndex)
+	let content = contentStart < line.endIndex
+		? String(line[contentStart...]).trimmingCharacters(in: .whitespaces)
+		: ""
+	return (id, content)
+}
+
+private func stripContinuationIndent(_ line: String) -> String? {
+	if line.hasPrefix("\t") {
+		return String(line.dropFirst())
+	}
+	if line.hasPrefix("    ") {
+		return String(line.dropFirst(4))
+	}
+	return nil
+}
+
+// MARK: - Reference scanning
+
+/// One token produced while scanning a `Text` node for `[^id]` references.
+enum FootnoteScanEvent {
+	case literal(String)
+	case reference(Int)
+}
+
+/// Scans `input` for `[^id]` references, asking `record` to assign a number to
+/// each well-formed id. A reference is replaced by a `.reference` event only
+/// when `record` returns a number (i.e. the id has a matching definition);
+/// otherwise the original `[^id]` text is preserved as literal output.
+///
+/// Both the HTML rewriter (sentinel strings) and the DOCX resolver (segments)
+/// build their output from these events so the scan rules stay in one place.
+func scanFootnoteReferences(in input: String, record: (String) -> Int?) -> [FootnoteScanEvent] {
+	guard input.contains("[^") else { return [.literal(input)] }
+
+	var events: [FootnoteScanEvent] = []
+	var pending = ""
+
+	var index = input.startIndex
+	while index < input.endIndex {
+		guard let openRange = input.range(of: "[^", range: index..<input.endIndex) else {
+			pending += input[index...]
+			break
+		}
+		pending += input[index..<openRange.lowerBound]
+
+		let idStart = openRange.upperBound
+		guard let closeIndex = input[idStart...].firstIndex(of: "]") else {
+			pending += input[openRange.lowerBound...]
+			break
+		}
+		let id = String(input[idStart..<closeIndex])
+		let consumedEnd = input.index(after: closeIndex)
+
+		let isValidShape = !id.isEmpty && !id.contains(where: { $0.isWhitespace })
+		if isValidShape, let number = record(id) {
+			if !pending.isEmpty {
+				events.append(.literal(pending))
+				pending = ""
+			}
+			events.append(.reference(number))
+		} else {
+			// No matching definition (or malformed id) — leave literal text.
+			pending += input[openRange.lowerBound..<consumedEnd]
+		}
+		index = consumedEnd
+	}
+
+	if !pending.isEmpty {
+		events.append(.literal(pending))
+	}
+	return events
+}
+
+// MARK: - Sentinels
+
+// Private Use Area characters — CommonMark-inert, not touched by the renderer's
+// HTML escape (which only rewrites `& < > "`), and vanishingly unlikely to
+// appear in user content.
+let footnoteSentinelOpen: Character = "\u{E000}"
+let footnoteSentinelClose: Character = "\u{E001}"
+
+func footnoteReferenceSentinel(number: Int) -> String {
+	"\(footnoteSentinelOpen)fnref:\(number)\(footnoteSentinelClose)"
+}
+
+// MARK: - State
+
+final class FootnoteState {
+	private let validIDs: Set<String>
+	private var numberByID: [String: Int] = [:]
+	private var nextNumber = 1
+	private var totalReferenceCountByNumber: [Int: Int] = [:]
+	private var emittedReferenceCountByNumber: [Int: Int] = [:]
+
+	init(definitionIDs: [String]) {
+		self.validIDs = Set(definitionIDs)
+	}
+
+	/// Assigns and returns the number for `id` on first reference. Returns
+	/// `nil` if no matching definition was extracted — callers then leave the
+	/// `[^id]` substring as literal text.
+	func recordReference(forID id: String) -> Int? {
+		guard validIDs.contains(id) else { return nil }
+		let number: Int
+		if let existing = numberByID[id] {
+			number = existing
+		} else {
+			number = nextNumber
+			numberByID[id] = number
+			nextNumber += 1
+		}
+		totalReferenceCountByNumber[number, default: 0] += 1
+		return number
+	}
+
+	/// Looks up an already-assigned number without recording a new reference.
+	/// Used after rewriting to fetch numbers for the definitions block.
+	func number(forID id: String) -> Int? {
+		numberByID[id]
+	}
+
+	/// Returns the next per-occurrence anchor id for a reference. The first
+	/// reference to footnote `N` gets `ref-N`; subsequent references get
+	/// `ref-N-2`, `ref-N-3`, … so each anchor in the HTML is unique.
+	func nextReferenceAnchorID(forNumber number: Int) -> String {
+		let occurrence = (emittedReferenceCountByNumber[number] ?? 0) + 1
+		emittedReferenceCountByNumber[number] = occurrence
+		return occurrence == 1 ? "ref-\(number)" : "ref-\(number)-\(occurrence)"
+	}
+}
+
+// MARK: - AST rewriter
+
+struct FootnoteReferenceRewriter: MarkupRewriter {
+	let state: FootnoteState
+
+	mutating func visitText(_ text: Text) -> Markup? {
+		let original = text.string
+		guard original.contains("[^") else { return text }
+		let rewritten = replaceReferences(in: original)
+		guard rewritten != original else { return text }
+		return Text(rewritten)
+	}
+
+	private func replaceReferences(in input: String) -> String {
+		// The scan rules (bounds, valid-id shape, skip-unmatched) live in
+		// `scanFootnoteReferences`; here we just turn the events into the
+		// sentinel string the HTML pass later expands.
+		var result = ""
+		result.reserveCapacity(input.count)
+		for event in scanFootnoteReferences(in: input, record: state.recordReference) {
+			switch event {
+			case .literal(let string):
+				result += string
+			case .reference(let number):
+				result += footnoteReferenceSentinel(number: number)
+			}
+		}
+		return result
+	}
+}

--- a/Sources/SwiftTextMarkdown/MarkdownFootnoteRenderer.swift
+++ b/Sources/SwiftTextMarkdown/MarkdownFootnoteRenderer.swift
@@ -23,6 +23,10 @@ import Markdown
 /// substituted — orphan references render as literal text. Numbers are
 /// assigned in source-order of first appearance (matching most GFM-style
 /// renderers).
+///
+/// The definition scanner and source-order numbering live in
+/// ``MarkdownFootnoteParser`` so the Markdown → DOCX writer can reuse them to
+/// emit native Word footnotes.
 public enum MarkdownFootnoteRenderer {
 
 	/// Converts Markdown to an HTML fragment, expanding `[^id]` footnote
@@ -30,7 +34,7 @@ public enum MarkdownFootnoteRenderer {
 	public static func convert(
 		_ markdown: String, options: SwiftMarkdownHTMLRenderer.Options = []
 	) -> String {
-		let (cleaned, definitions) = extractDefinitions(from: markdown)
+		let (cleaned, definitions) = extractFootnoteDefinitions(from: markdown)
 
 		// Fast path: no definitions at all -> nothing to rewrite, render directly.
 		if definitions.isEmpty {
@@ -82,224 +86,6 @@ public enum MarkdownFootnoteRenderer {
 	}
 }
 
-// MARK: - Definition extraction
-
-private struct FootnoteDefinition {
-	let id: String
-	let body: String
-}
-
-/// Scans source markdown for `[^id]: …` definition blocks. Returns the source
-/// with those blocks removed, plus the captured definitions in source order.
-///
-/// A definition spans the marker line plus any subsequent lines that are either
-/// blank or indented by at least 4 spaces / one tab (the standard GFM rule).
-/// Indentation is stripped from continuation lines so the captured body is plain
-/// Markdown.
-private func extractDefinitions(from source: String) -> (cleaned: String, definitions: [FootnoteDefinition]) {
-	let normalized = source
-		.replacingOccurrences(of: "\r\n", with: "\n")
-		.replacingOccurrences(of: "\r", with: "\n")
-	let lines = normalized.components(separatedBy: "\n")
-
-	var keptLines: [String] = []
-	keptLines.reserveCapacity(lines.count)
-
-	var definitions: [FootnoteDefinition] = []
-	var seenIDs = Set<String>()
-
-	var i = 0
-	while i < lines.count {
-		let line = lines[i]
-
-		guard let start = parseDefinitionStart(line) else {
-			keptLines.append(line)
-			i += 1
-			continue
-		}
-
-		// Collect body lines: the inline content after `]:`, plus any
-		// indented/blank continuation lines.
-		var bodyLines: [String] = []
-		if !start.firstLineContent.isEmpty {
-			bodyLines.append(start.firstLineContent)
-		}
-
-		var j = i + 1
-		while j < lines.count {
-			let next = lines[j]
-			if next.trimmingCharacters(in: .whitespaces).isEmpty {
-				// Look ahead: if the next non-blank line is also indented, the
-				// blank line is part of the definition (paragraph break inside);
-				// otherwise it terminates the definition.
-				var lookahead = j + 1
-				while lookahead < lines.count && lines[lookahead].trimmingCharacters(in: .whitespaces).isEmpty {
-					lookahead += 1
-				}
-				if lookahead < lines.count, stripContinuationIndent(lines[lookahead]) != nil {
-					bodyLines.append("")
-					j += 1
-					continue
-				}
-				break
-			}
-			if let stripped = stripContinuationIndent(next) {
-				bodyLines.append(stripped)
-				j += 1
-				continue
-			}
-			break
-		}
-
-		// Skip duplicate definitions — first wins.
-		if !seenIDs.contains(start.id) {
-			definitions.append(FootnoteDefinition(id: start.id, body: bodyLines.joined(separator: "\n")))
-			seenIDs.insert(start.id)
-		}
-
-		i = j
-	}
-
-	return (keptLines.joined(separator: "\n"), definitions)
-}
-
-private func parseDefinitionStart(_ line: String) -> (id: String, firstLineContent: String)? {
-	guard line.hasPrefix("[^"),
-	      let closingBracket = line.firstIndex(of: "]") else { return nil }
-	let identifierStart = line.index(line.startIndex, offsetBy: 2)
-	guard identifierStart < closingBracket else { return nil }
-	let colonIndex = line.index(after: closingBracket)
-	guard colonIndex < line.endIndex, line[colonIndex] == ":" else { return nil }
-
-	let id = String(line[identifierStart..<closingBracket]).trimmingCharacters(in: .whitespaces)
-	guard !id.isEmpty else { return nil }
-
-	let contentStart = line.index(after: colonIndex)
-	let content = contentStart < line.endIndex
-		? String(line[contentStart...]).trimmingCharacters(in: .whitespaces)
-		: ""
-	return (id, content)
-}
-
-private func stripContinuationIndent(_ line: String) -> String? {
-	if line.hasPrefix("\t") {
-		return String(line.dropFirst())
-	}
-	if line.hasPrefix("    ") {
-		return String(line.dropFirst(4))
-	}
-	return nil
-}
-
-// MARK: - Sentinels
-
-// Private Use Area characters — CommonMark-inert, not touched by the renderer's
-// HTML escape (which only rewrites `& < > "`), and vanishingly unlikely to
-// appear in user content.
-private let sentinelOpen: Character = "\u{E000}"
-private let sentinelClose: Character = "\u{E001}"
-
-private func referenceSentinel(number: Int) -> String {
-	"\(sentinelOpen)fnref:\(number)\(sentinelClose)"
-}
-
-// MARK: - State
-
-private final class FootnoteState {
-	private let validIDs: Set<String>
-	private var numberByID: [String: Int] = [:]
-	private var nextNumber = 1
-	private var totalReferenceCountByNumber: [Int: Int] = [:]
-	private var emittedReferenceCountByNumber: [Int: Int] = [:]
-
-	init(definitionIDs: [String]) {
-		self.validIDs = Set(definitionIDs)
-	}
-
-	/// Assigns and returns the number for `id` on first reference. Returns
-	/// `nil` if no matching definition was extracted — the rewriter then leaves
-	/// the `[^id]` substring as literal text.
-	func recordReference(forID id: String) -> Int? {
-		guard validIDs.contains(id) else { return nil }
-		let number: Int
-		if let existing = numberByID[id] {
-			number = existing
-		} else {
-			number = nextNumber
-			numberByID[id] = number
-			nextNumber += 1
-		}
-		totalReferenceCountByNumber[number, default: 0] += 1
-		return number
-	}
-
-	/// Looks up an already-assigned number without recording a new reference.
-	/// Used after rewriting to fetch numbers for the definitions block.
-	func number(forID id: String) -> Int? {
-		numberByID[id]
-	}
-
-	/// Returns the next per-occurrence anchor id for a reference. The first
-	/// reference to footnote `N` gets `ref-N`; subsequent references get
-	/// `ref-N-2`, `ref-N-3`, … so each anchor in the HTML is unique.
-	func nextReferenceAnchorID(forNumber number: Int) -> String {
-		let occurrence = (emittedReferenceCountByNumber[number] ?? 0) + 1
-		emittedReferenceCountByNumber[number] = occurrence
-		return occurrence == 1 ? "ref-\(number)" : "ref-\(number)-\(occurrence)"
-	}
-}
-
-// MARK: - AST rewriter
-
-private struct FootnoteReferenceRewriter: MarkupRewriter {
-	let state: FootnoteState
-
-	mutating func visitText(_ text: Text) -> Markup? {
-		let original = text.string
-		guard original.contains("[^") else { return text }
-		let rewritten = replaceReferences(in: original)
-		guard rewritten != original else { return text }
-		return Text(rewritten)
-	}
-
-	private func replaceReferences(in input: String) -> String {
-		// We scan manually rather than with NSRegularExpression so we can keep
-		// the bounds rules simple: `[^` opens, the next `]` closes, the id is
-		// non-empty and contains no whitespace or `]`. This matches the
-		// hand-rolled parser's behavior closely enough for parity.
-		var result = ""
-		result.reserveCapacity(input.count)
-
-		var index = input.startIndex
-		while index < input.endIndex {
-			guard let openRange = input.range(of: "[^", range: index..<input.endIndex) else {
-				result.append(contentsOf: input[index...])
-				break
-			}
-			result.append(contentsOf: input[index..<openRange.lowerBound])
-
-			let idStart = openRange.upperBound
-			guard let closeIndex = input[idStart...].firstIndex(of: "]") else {
-				result.append(contentsOf: input[openRange.lowerBound...])
-				break
-			}
-			let id = String(input[idStart..<closeIndex])
-			let consumedEnd = input.index(after: closeIndex)
-
-			let isValidShape = !id.isEmpty && !id.contains(where: { $0.isWhitespace })
-			if isValidShape, let number = state.recordReference(forID: id) {
-				result.append(referenceSentinel(number: number))
-			} else {
-				// No matching definition (or malformed id) — leave literal text.
-				result.append(contentsOf: input[openRange.lowerBound..<consumedEnd])
-			}
-			index = consumedEnd
-		}
-
-		return result
-	}
-}
-
 // MARK: - Sentinel expansion
 
 /// Replaces every sentinel in `html` with a `<sup><a …>[N]</a></sup>` anchor.
@@ -307,21 +93,21 @@ private struct FootnoteReferenceRewriter: MarkupRewriter {
 /// appear in the rendered HTML), which lets the definitions block link back to
 /// the first occurrence cleanly.
 private func expandSentinels(in html: String, state: FootnoteState) -> String {
-	guard html.contains(sentinelOpen) else { return html }
+	guard html.contains(footnoteSentinelOpen) else { return html }
 
 	var result = ""
 	result.reserveCapacity(html.count)
 
 	var index = html.startIndex
 	while index < html.endIndex {
-		guard let openIndex = html[index...].firstIndex(of: sentinelOpen) else {
+		guard let openIndex = html[index...].firstIndex(of: footnoteSentinelOpen) else {
 			result.append(contentsOf: html[index...])
 			break
 		}
 		result.append(contentsOf: html[index..<openIndex])
 
 		let payloadStart = html.index(after: openIndex)
-		guard let closeIndex = html[payloadStart...].firstIndex(of: sentinelClose) else {
+		guard let closeIndex = html[payloadStart...].firstIndex(of: footnoteSentinelClose) else {
 			// Malformed — emit the rest verbatim and stop.
 			result.append(contentsOf: html[openIndex...])
 			break

--- a/Tests/SwiftTextDOCXTests/DocxFootnoteWriterTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxFootnoteWriterTests.swift
@@ -1,0 +1,105 @@
+import Foundation
+import SwiftTextDOCX
+import Testing
+import ZIPFoundation
+
+@Suite("DOCX footnote writer")
+struct DocxFootnoteWriterTests {
+
+	@Test("Markdown footnotes become a native word/footnotes.xml part with a w:footnoteReference")
+	func writesNativeFootnotes() throws {
+		let markdown = """
+		Body text[^1] here, with a note.
+
+		[^1]: The footnote body text.
+		"""
+
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("fn-writer-\(UUID().uuidString).docx")
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		try MarkdownToDocx.convert(markdown, to: url)
+
+		let archive = try #require(Archive(url: url, accessMode: .read))
+
+		func part(_ path: String) throws -> String {
+			let entry = try #require(archive[path], "missing part \(path)")
+			var data = Data()
+			_ = try archive.extract(entry) { data.append($0) }
+			return String(decoding: data, as: UTF8.self)
+		}
+
+		// The footnotes part exists and holds the note body plus the required
+		// separator / continuationSeparator pseudo-footnotes.
+		let footnotes = try part("word/footnotes.xml")
+		#expect(footnotes.contains("The footnote body text."))
+		#expect(footnotes.contains("w:type=\"separator\""))
+		#expect(footnotes.contains("w:type=\"continuationSeparator\""))
+		#expect(footnotes.contains("<w:footnote w:id=\"1\">"))
+		#expect(footnotes.contains("<w:footnoteRef/>"))
+
+		// The body has a real footnote reference run (superscript style + id).
+		let document = try part("word/document.xml")
+		#expect(document.contains("<w:footnoteReference w:id=\"1\"/>"))
+		#expect(document.contains("<w:rStyle w:val=\"FootnoteReference\"/>"))
+		// The literal definition/reference markup must not leak as plain text.
+		#expect(!document.contains("[^1]"))
+
+		// The part is registered in both the content types and the document rels.
+		let contentTypes = try part("[Content_Types].xml")
+		#expect(contentTypes.contains("/word/footnotes.xml"))
+		#expect(contentTypes.contains("wordprocessingml.footnotes+xml"))
+
+		let rels = try part("word/_rels/document.xml.rels")
+		#expect(rels.contains("relationships/footnotes"))
+		#expect(rels.contains("Target=\"footnotes.xml\""))
+
+		// The styles required to render the footnote are present.
+		let styles = try part("word/styles.xml")
+		#expect(styles.contains("w:styleId=\"FootnoteText\""))
+		#expect(styles.contains("w:styleId=\"FootnoteReference\""))
+		#expect(styles.contains("<w:vertAlign w:val=\"superscript\"/>"))
+	}
+
+	@Test("Written footnotes round-trip back through the DOCX reader")
+	func footnotesRoundTrip() throws {
+		let markdown = """
+		First claim[^a] and a second[^b].
+
+		[^a]: See the appendix.
+		[^b]: Ibid.
+		"""
+
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("fn-roundtrip-\(UUID().uuidString).docx")
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		try MarkdownToDocx.convert(markdown, to: url)
+
+		// The reader renumbers in reference order, so [^a]/[^b] come back as
+		// [^1]/[^2] with their definitions collected at the end.
+		#expect(try DocxFile(url: url).markdown() == """
+		First claim[^1] and a second[^2].
+
+		[^1]: See the appendix.
+		[^2]: Ibid.
+		""")
+	}
+
+	@Test("A document without footnotes emits no footnotes part")
+	func noFootnotesNoPart() throws {
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("fn-none-\(UUID().uuidString).docx")
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		try MarkdownToDocx.convert("Just a plain paragraph.", to: url)
+
+		let archive = try #require(Archive(url: url, accessMode: .read))
+		#expect(archive["word/footnotes.xml"] == nil)
+
+		var data = Data()
+		let entry = try #require(archive["[Content_Types].xml"])
+		_ = try archive.extract(entry) { data.append($0) }
+		#expect(!String(decoding: data, as: UTF8.self).contains("footnotes"))
+	}
+}

--- a/Tests/SwiftTextDOCXTests/DocxFootnoteWriterTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxFootnoteWriterTests.swift
@@ -102,4 +102,56 @@ struct DocxFootnoteWriterTests {
 		_ = try archive.extract(entry) { data.append($0) }
 		#expect(!String(decoding: data, as: UTF8.self).contains("footnotes"))
 	}
+
+	@Test("A footnote reference inside a table header cell is rendered, not dropped")
+	func tableHeaderFootnoteRenders() throws {
+		let markdown = """
+		| Metric[^h] | Value |
+		| --- | --- |
+		| Speed | Fast |
+
+		[^h]: Measured on the test rig.
+		"""
+
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("fn-thead-\(UUID().uuidString).docx")
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		try MarkdownToDocx.convert(markdown, to: url)
+
+		let archive = try #require(Archive(url: url, accessMode: .read))
+		// The only reference is in the header cell, so its presence proves the
+		// header path renders footnote runs (it now goes through renderRuns).
+		#expect(try part("word/document.xml", from: archive).contains("<w:footnoteReference w:id=\"1\"/>"))
+		// And the matching note body is emitted — no orphaned footnote.
+		#expect(try part("word/footnotes.xml", from: archive).contains("Measured on the test rig."))
+	}
+
+	@Test("parseBlocks leaves footnotes as literal text — the low-level path emits no orphan references")
+	func parseBlocksKeepsFootnotesLiteral() throws {
+		// A caller using the documented low-level flow assigns parseBlocks output
+		// straight to DocxWriter.blocks. Since that path can't carry footnote
+		// bodies, it must not emit footnote-reference runs (which would be orphans).
+		let writer = DocxWriter()
+		writer.blocks = MarkdownToDocx.parseBlocks("See note[^1].\n\n[^1]: The note.")
+
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("fn-parseblocks-\(UUID().uuidString).docx")
+		defer { try? FileManager.default.removeItem(at: url) }
+		try writer.write(to: url)
+
+		let archive = try #require(Archive(url: url, accessMode: .read))
+		#expect(archive["word/footnotes.xml"] == nil)
+		let document = try part("word/document.xml", from: archive)
+		#expect(!document.contains("<w:footnoteReference"))
+		#expect(document.contains("[^1]"))  // reference stays literal
+	}
+
+	/// Reads a part out of a `.docx` archive as a UTF-8 string.
+	private func part(_ path: String, from archive: Archive) throws -> String {
+		let entry = try #require(archive[path], "missing part \(path)")
+		var data = Data()
+		_ = try archive.extract(entry) { data.append($0) }
+		return String(decoding: data, as: UTF8.self)
+	}
 }


### PR DESCRIPTION
## What

The Markdown→DOCX writer left `[^id]` footnote references and `[^id]: …` definitions as **literal text** (swift-markdown has no footnote AST node), so they rendered as plain `[^1]` in Word/Pages instead of real page-bottom footnotes. This implements native Word footnotes, closing the write side so DOCX footnotes now **round-trip** (the reader already parsed `word/footnotes.xml`).

## How

**Reuse the existing scanner instead of re-implementing it.** The definition extractor, source-order numbering, and `[^id]` reference rewriting (which already skips `InlineCode`/`CodeBlock`) move out of `MarkdownFootnoteRenderer` into a shared, format-agnostic `MarkdownFootnoteParser` / `MarkdownFootnoteResolver` in `SwiftTextMarkdown`:

- The **HTML renderer** keeps its sentinel pipeline, now built on the shared scanner — behavior unchanged.
- The **DOCX builder** splits each `Text` node into `.text` / `.reference(N)` segments and emits a footnote run per reference.

`DocxWriter` now emits (only when footnotes exist):
- `word/footnotes.xml` with the note bodies plus the required `separator`/`continuationSeparator` pseudo-footnotes at ids `-1`/`0`;
- `w:footnoteReference w:id="N"` runs (with the `FootnoteReference` superscript char style) at each reference point in `document.xml`;
- the part registered in `[Content_Types].xml` and `word/_rels/document.xml.rels`;
- `FootnoteText` / `FootnoteReference` styles in `styles.xml`.

This parallels the native footnote work on the Pages writer (`claude/pages-native-tables`, merged).

## Notes for reviewers

- Footnote ids equal the 1-based footnote number; the reader renumbers in reference order, so `[^a]`/`[^b]` round-trip back as `[^1]`/`[^2]`.
- Footnote bodies render links as plain styled text (no `word/footnotes.xml.rels`) and degrade a nested footnote reference to a superscript `[N]` — Word can't nest footnotes. A standalone image inside a footnote degrades to its italic alt-text.
- Em-dashes in footnote text render as `---`, the pre-existing DOCX smart-punct reversal applied to all body text — not specific to footnotes.

## Testing

- New `Tests/SwiftTextDOCXTests/DocxFootnoteWriterTests.swift`: asserts the `word/footnotes.xml` part + note text + `w:footnoteReference` in `document.xml`, content-types/rels/styles registration, a **reader round-trip**, and that a footnote-free document emits no part.
- Full suite green (270 tests / 39 suites).
- Rendered `~/Downloads/showcase/showcase.md` and opened in **Pages**: superscript ref in the body, note text pinned to the page bottom under the separator rule — a genuine native footnote (coexisting with the embedded banner image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)