### PR TITLE
Add render --page-break-before to start chapters on new pages

### DIFF
--- a/Scripts/manuscript-to-pdf.sh
+++ b/Scripts/manuscript-to-pdf.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# manuscript-to-pdf.sh — render a Markdown manuscript to a print-ready PDF
+# using the `swifttext` CLI, with every chapter (an h2 heading) starting on a
+# fresh page.
+#
+# Usage:
+#   Scripts/manuscript-to-pdf.sh [INPUT.md] [OUTPUT.pdf]
+#
+# Defaults to the Shattered Skies manuscript and writes a sibling .pdf.
+#
+set -euo pipefail
+
+# --- locate the Swift package (this script lives in <package>/Scripts) --------
+PKG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Keep SwiftPM build artifacts off the internal disk (see global build policy).
+SCRATCH="/Volumes/SSD/SwiftPM/$(basename "$PKG_ROOT")"
+[ -d /Volumes/SSD ] || SCRATCH="$PKG_ROOT/.build"
+
+# --- arguments ----------------------------------------------------------------
+INPUT="${1:-/Users/oliver/Developer/Canon/Project/manuscript/The-Shattered-Skies.md}"
+OUTPUT="${2:-${INPUT%.*}.pdf}"
+
+if [ ! -f "$INPUT" ]; then
+	echo "error: manuscript not found: $INPUT" >&2
+	exit 1
+fi
+
+# --- build the CLI once, then invoke the built binary -------------------------
+echo "Building swifttext (release) → $SCRATCH ..." >&2
+swift build -c release --scratch-path "$SCRATCH" --product swifttext --package-path "$PKG_ROOT"
+BIN="$(swift build -c release --scratch-path "$SCRATCH" --product swifttext --package-path "$PKG_ROOT" --show-bin-path)/swifttext"
+
+# --- render -------------------------------------------------------------------
+# --page-break-before h2 forces each chapter (## heading) onto a new page.
+echo "Rendering $INPUT → $OUTPUT ..." >&2
+"$BIN" render "$INPUT" --output "$OUTPUT" --format pdf --paper a4 --page-break-before h2
+
+echo "Wrote $OUTPUT" >&2

--- a/Sources/SwiftTextCLI/PDFCommand.swift
+++ b/Sources/SwiftTextCLI/PDFCommand.swift
@@ -339,10 +339,19 @@ struct PDF: AsyncParsableCommand {
 
 /// Converts a Markdown string to a self-contained HTML document
 /// styled for print output and with CSS `@page` size directives.
-func markdownToHTML(_ markdown: String, paper: PaperSize, landscape: Bool) -> String {
+func markdownToHTML(_ markdown: String, paper: PaperSize, landscape: Bool, pageBreakBefore: HeadingBreakLevel? = nil) -> String {
 	let orientation = landscape ? "landscape" : "portrait"
 	let pageCSS = "\(paper.cssName) \(orientation)"
 	let body = MarkdownToHTML.convert(markdown)
+	// Optional forced page break before a given heading level (e.g. h2 so each
+	// chapter starts on a new page). Placed after the base heading rules so it
+	// wins on source order; the leading break is ignored by the print engine
+	// when the heading is the first box, so no blank first page is emitted.
+	let headingBreakCSS = pageBreakBefore.map { level in
+		"""
+		\(level.rawValue) { page-break-before: always; break-before: page; }
+		"""
+	} ?? ""
 	return """
 	<!DOCTYPE html>
 	<html lang="en">
@@ -479,6 +488,7 @@ func markdownToHTML(_ markdown: String, paper: PaperSize, landscape: Bool) -> St
 	    font-size: 0.95em;
 	}
 	.footnote-definition p { margin: 0.4em 0; }
+	\(headingBreakCSS)
 	</style>
 	</head>
 	<body>

--- a/Sources/SwiftTextCLI/RenderCommand.swift
+++ b/Sources/SwiftTextCLI/RenderCommand.swift
@@ -19,6 +19,11 @@ enum RenderOutputFormat: String, ExpressibleByArgument, CaseIterable {
 	case pages
 }
 
+/// Heading level before which a page break is forced (PDF/HTML print output).
+enum HeadingBreakLevel: String, ExpressibleByArgument, CaseIterable {
+	case h1, h2, h3, h4, h5, h6
+}
+
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 struct Render: AsyncParsableCommand {
 	static let configuration = CommandConfiguration(
@@ -43,6 +48,9 @@ struct Render: AsyncParsableCommand {
 
 	@Flag(name: .long, help: "Use landscape orientation (default: portrait).")
 	var landscape: Bool = false
+
+	@Option(name: .long, help: "For PDF/HTML output, force a page break before every heading of this level (h1–h6). Use h2 to start each chapter on its own page. Omit to disable.")
+	var pageBreakBefore: HeadingBreakLevel?
 
 	@Flag(name: .long, help: "For Pages output, write a directory-package bundle instead of a single file.")
 	var package: Bool = false
@@ -78,11 +86,11 @@ struct Render: AsyncParsableCommand {
 
 		switch chosenFormat {
 		case .html:
-			let html = markdownToHTML(markdownText, paper: paper, landscape: landscape)
+			let html = markdownToHTML(markdownText, paper: paper, landscape: landscape, pageBreakBefore: pageBreakBefore)
 			try writeString(html, to: outputURL)
 			print(outputURL.path)
 		case .pdf:
-			let html = markdownToHTML(markdownText, paper: paper, landscape: landscape)
+			let html = markdownToHTML(markdownText, paper: paper, landscape: landscape, pageBreakBefore: pageBreakBefore)
 			try await renderPDF(html: html, baseURL: baseURL, outputURL: outputURL)
 			print(outputURL.path)
 		case .docx:


### PR DESCRIPTION
## What

Adds an optional `--page-break-before <h1–h6>` option to `swifttext render`. When set, it forces a page break before every heading of that level in PDF/HTML output — e.g. `--page-break-before h2` starts each chapter on its own page.

Also adds `Scripts/manuscript-to-pdf.sh`, which builds the CLI and renders a Markdown manuscript to PDF with `--page-break-before h2` end to end.

## Why

The `render` command's print CSS had no forced page breaks for headings, and the render path escapes raw HTML in the Markdown (`passThroughRawHTML` is off). So a caller had no way to make each chapter begin on a fresh page — neither via CSS nor by injecting markup. This closes that gap with a small, explicit option.

## How

- `markdownToHTML` gains a defaulted `pageBreakBefore: HeadingBreakLevel?` parameter and injects `break-before: page` / `page-break-before: always` for the chosen level, placed after the base heading rules so it wins on source order. The leading break is ignored by the print engine when the heading is the first box, so no blank first page is emitted.
- New `HeadingBreakLevel` enum (`h1`–`h6`, `ExpressibleByArgument`) and `--page-break-before` option on `Render`, threaded through the `.html` and `.pdf` cases.
- The default is off, and the PDF subcommand's `markdownToHTML` callers are untouched (they rely on the defaulted parameter), so existing output is unchanged.

## Notes for reviewers

- Scope is PDF/HTML only; DOCX and Pages go through separate converters and are unaffected (reflected in the option's help text).
- Verified against a 16-chapter manuscript: each `##` heading lands at the top of its own page, with no page carrying two headings.
- SwiftLint is clean on both changed files; the `swifttext` product builds and runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)