### PR TITLE
Fix smart-punctuation reversal mangling literal typographic characters

### DIFF
--- a/Sources/SwiftTextAttributedString/MarkdownAttributedStringRenderer.swift
+++ b/Sources/SwiftTextAttributedString/MarkdownAttributedStringRenderer.swift
@@ -31,8 +31,9 @@ public enum MarkdownAttributedStringRenderer {
 		public let rawValue: Int
 		public init(rawValue: Int) { self.rawValue = rawValue }
 
-		/// Keep cmark-gfm's smart typographic characters instead of reversing
-		/// them to their literal source spelling (`"`, `'`, `--`, `---`, `...`).
+		/// Let cmark-gfm smart-substitute typed `--`/`---`/`...`/straight quotes
+		/// into dashes/ellipsis/curly quotes, instead of parsing with
+		/// `.disableSmartOpts` (the default) to keep literal source spelling.
 		public static let preserveSmartPunctuation = Options(rawValue: 1 << 0)
 	}
 
@@ -41,9 +42,11 @@ public enum MarkdownAttributedStringRenderer {
 	public static func convert(_ markdown: String, options: Options = []) -> AttributedString {
 		let (cleaned, definitions) = MarkdownFootnoteParser.extractDefinitions(from: markdown)
 
+		let parseOptions: ParseOptions = options.contains(.preserveSmartPunctuation) ? [] : [.disableSmartOpts]
+
 		guard !definitions.isEmpty else {
 			let builder = Builder(options: options, resolver: nil)
-			builder.emitBlocks(Document(parsing: cleaned, options: []).children, EmitContext())
+			builder.emitBlocks(Document(parsing: cleaned, options: parseOptions).children, EmitContext())
 			return builder.result
 		}
 
@@ -51,7 +54,7 @@ public enum MarkdownAttributedStringRenderer {
 		let builder = Builder(options: options, resolver: resolver)
 
 		// Body first so footnote numbers are assigned in source order.
-		builder.emitBlocks(Document(parsing: cleaned, options: []).children, EmitContext())
+		builder.emitBlocks(Document(parsing: cleaned, options: parseOptions).children, EmitContext())
 		// Then the trailing definitions block (resolves references nested in
 		// definition bodies too).
 		builder.emitFootnoteDefinitions(definitions)
@@ -291,7 +294,8 @@ private final class Builder {
 	private func emitFootnoteDefinition(_ body: String, number: Int) {
 		var context = EmitContext()
 		context.footnoteDefinition = number
-		let blocks = Array(Document(parsing: body, options: []).children)
+		let parseOptions: ParseOptions = preserveSmartPunctuation ? [] : [.disableSmartOpts]
+		let blocks = Array(Document(parsing: body, options: parseOptions).children)
 
 		guard !blocks.isEmpty else {
 			append("\(number). ", block: leaf(.paragraph, context), style: .stronglyEmphasized, context)
@@ -341,7 +345,7 @@ private final class Builder {
 			nested.link = (link.destination).flatMap(URL.init(string:)) ?? accumulator.link
 			for child in link.children { emitInline(child, nested, block: block, context) }
 		case let image as Image:
-			let alt = reverseSmart(swiftMarkdownPlainText(of: image))
+			let alt = swiftMarkdownPlainText(of: image)
 			append(alt, block: block, style: accumulator.style, link: accumulator.link, context, imageSource: image.source)
 		case let inlineHTML as InlineHTML:
 			var style = accumulator.style
@@ -376,13 +380,13 @@ private final class Builder {
 		block: [MarkdownBlock.Component]?, _ context: EmitContext
 	) {
 		guard let resolver else {
-			append(reverseSmart(string), block: block, style: accumulator.style, link: accumulator.link, context)
+			append(string, block: block, style: accumulator.style, link: accumulator.link, context)
 			return
 		}
 		for segment in resolver.resolve(string) {
 			switch segment {
 			case .text(let value):
-				append(reverseSmart(value), block: block, style: accumulator.style, link: accumulator.link, context)
+				append(value, block: block, style: accumulator.style, link: accumulator.link, context)
 			case .reference(let number):
 				append("\(number)", block: block, style: accumulator.style, link: accumulator.link, context, footnoteReference: number)
 			}
@@ -422,10 +426,6 @@ private final class Builder {
 		#endif
 
 		result.append(AttributedString(text, attributes: container))
-	}
-
-	private func reverseSmart(_ string: String) -> String {
-		preserveSmartPunctuation ? string : reverseSmartPunctuation(string)
 	}
 
 	/// Foundation uses U+2E3B (THREE-EM DASH) as a thematic-break placeholder.
@@ -537,32 +537,3 @@ extension Builder {
 	}
 }
 #endif
-
-// MARK: - Smart punctuation reversal (shared policy with the HTML renderer)
-
-private func reverseSmartPunctuation(_ string: String) -> String {
-	guard string.contains(where: isSmartCharacter) else { return string }
-	var result = ""
-	result.reserveCapacity(string.count)
-	for character in string {
-		switch character {
-		case "\u{2018}", "\u{2019}": result.append("'")   // ‘ ’
-		case "\u{201C}", "\u{201D}": result.append("\"")  // “ ”
-		case "\u{2013}": result.append("--")               // –
-		case "\u{2014}": result.append("---")              // —
-		case "\u{2026}": result.append("...")              // …
-		default: result.append(character)
-		}
-	}
-	return result
-}
-
-private func isSmartCharacter(_ character: Character) -> Bool {
-	switch character {
-	case "\u{2018}", "\u{2019}", "\u{201C}", "\u{201D}",
-		 "\u{2013}", "\u{2014}", "\u{2026}":
-		return true
-	default:
-		return false
-	}
-}

--- a/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
+++ b/Sources/SwiftTextDOCX/MarkdownDocxBuilder.swift
@@ -65,7 +65,7 @@ enum MarkdownDocxBuilder {
 	}
 
 	private static func blocks(from markdown: String, resolver: MarkdownFootnoteResolver?) -> [DocxWriter.Block] {
-		let document = Document(parsing: markdown, options: [])
+		let document = Document(parsing: markdown, options: [.disableSmartOpts])
 		var visitor = BlockVisitor(resolver: resolver)
 		visitor.visit(document)
 		return visitor.blocks
@@ -74,7 +74,7 @@ enum MarkdownDocxBuilder {
 	/// Parses inline Markdown into a flat run list. Treats the input as the
 	/// inline content of a paragraph — block-level constructs are ignored.
 	static func runs(fromInline text: String) -> [DocxWriter.Run] {
-		let document = Document(parsing: text, options: [])
+		let document = Document(parsing: text, options: [.disableSmartOpts])
 		guard let firstParagraph = document.child(at: 0) as? Paragraph else { return [] }
 		return runs(from: firstParagraph, resolver: nil)
 	}
@@ -145,7 +145,7 @@ private struct RunCollector {
 			// descendants so alt text from nested inline formatting is
 			// preserved (e.g. `![*logo*](...)` keeps "logo" instead of
 			// falling through to the `[image]` placeholder).
-			let alt = reverseSmartPunct(swiftMarkdownPlainText(of: image))
+			let alt = swiftMarkdownPlainText(of: image)
 			let display = alt.isEmpty ? "[image]" : alt
 			runs.append(DocxWriter.Run(text: display, italic: true))
 		case let inlineHTML as InlineHTML:
@@ -175,13 +175,13 @@ private struct RunCollector {
 	/// runs. Without a resolver this is just `append(text:)`.
 	private mutating func appendResolvingFootnotes(in string: String) {
 		guard let resolver else {
-			append(text: reverseSmartPunct(string))
+			append(text: string)
 			return
 		}
 		for segment in resolver.resolve(string) {
 			switch segment {
 			case .text(let value):
-				if !value.isEmpty { append(text: reverseSmartPunct(value)) }
+				if !value.isEmpty { append(text: value) }
 			case .reference(let number):
 				runs.append(DocxWriter.Run(text: "", footnoteRef: number))
 			}
@@ -225,7 +225,7 @@ private struct BlockVisitor: MarkupVisitor {
 		let children = Array(paragraph.children)
 		if children.count == 1, let image = children.first as? Image,
 		   let source = image.source, !source.isEmpty {
-			let alt = reverseSmartPunct(swiftMarkdownPlainText(of: image))
+			let alt = swiftMarkdownPlainText(of: image)
 			blocks.append(.image(source: source, alt: alt))
 			return
 		}
@@ -317,33 +317,4 @@ private struct BlockVisitor: MarkupVisitor {
 	// HTML blocks aren't representable in our DocxWriter block model — the
 	// legacy parser dropped them silently. Match that.
 	mutating func visitHTMLBlock(_ htmlBlock: HTMLBlock) {}
-}
-
-// MARK: - Smart-punct reversal
-
-private func reverseSmartPunct(_ string: String) -> String {
-	guard string.contains(where: isSmartCharacter) else { return string }
-	var result = ""
-	result.reserveCapacity(string.count)
-	for character in string {
-		switch character {
-		case "\u{2018}", "\u{2019}": result.append("'")
-		case "\u{201C}", "\u{201D}": result.append("\"")
-		case "\u{2013}": result.append("--")
-		case "\u{2014}": result.append("---")
-		case "\u{2026}": result.append("...")
-		default: result.append(character)
-		}
-	}
-	return result
-}
-
-private func isSmartCharacter(_ character: Character) -> Bool {
-	switch character {
-	case "\u{2018}", "\u{2019}", "\u{201C}", "\u{201D}",
-		 "\u{2013}", "\u{2014}", "\u{2026}":
-		return true
-	default:
-		return false
-	}
 }

--- a/Sources/SwiftTextMarkdown/MarkdownFootnoteRenderer.swift
+++ b/Sources/SwiftTextMarkdown/MarkdownFootnoteRenderer.swift
@@ -44,7 +44,7 @@ public enum MarkdownFootnoteRenderer {
 		let state = FootnoteState(definitionIDs: definitions.map { $0.id })
 
 		// Rewrite references in the main body.
-		let bodyDocument = Document(parsing: cleaned, options: [])
+		let bodyDocument = Document(parsing: cleaned, options: [.disableSmartOpts])
 		var bodyRewriter = FootnoteReferenceRewriter(state: state)
 		let rewrittenBody = bodyRewriter.visit(bodyDocument) as? Document ?? bodyDocument
 		let bodyHTML = SwiftMarkdownHTMLRenderer.convert(document: rewrittenBody, options: options)
@@ -64,7 +64,7 @@ public enum MarkdownFootnoteRenderer {
 					// Definition not referenced (yet) — skip it.
 					continue
 				}
-				let defDocument = Document(parsing: definition.body, options: [])
+				let defDocument = Document(parsing: definition.body, options: [.disableSmartOpts])
 				var defRewriter = FootnoteReferenceRewriter(state: state)
 				let rewrittenDef = defRewriter.visit(defDocument) as? Document ?? defDocument
 				let defBodyHTML = SwiftMarkdownHTMLRenderer.convert(document: rewrittenDef, options: options)

--- a/Sources/SwiftTextMarkdown/SwiftMarkdownHTMLRenderer.swift
+++ b/Sources/SwiftTextMarkdown/SwiftMarkdownHTMLRenderer.swift
@@ -17,9 +17,12 @@ import Markdown
 /// - GitHub alert syntax (`> [!NOTE]`) is detected after parsing by inspecting
 ///   the first inline of each `BlockQuote`. swift-markdown's `Aside` node is
 ///   DocC-style only, so we detect the bracket-bang form ourselves.
-/// - cmark-gfm enables smart punctuation by default. We reverse the smart
-///   characters (curly quotes, en/em dashes, ellipsis) on the way out so the
-///   output matches the literal source — same policy as the legacy parser.
+/// - cmark-gfm enables smart punctuation by default (typed `--`/`---`/`...`/
+///   straight quotes become dashes/ellipsis/curly quotes). We parse with
+///   `.disableSmartOpts` so that conversion never happens, matching the
+///   legacy parser's policy of literal source fidelity — and, unlike
+///   reversing the substitution after the fact, this also leaves any
+///   typographic characters already present in the source untouched.
 /// - Output is the inline HTML fragment — no `<html>`/`<body>` wrapper.
 public enum SwiftMarkdownHTMLRenderer {
 
@@ -38,7 +41,7 @@ public enum SwiftMarkdownHTMLRenderer {
 	}
 
 	public static func convert(_ markdown: String, options: Options = []) -> String {
-		let document = Document(parsing: markdown, options: [])
+		let document = Document(parsing: markdown, options: [.disableSmartOpts])
 		return convert(document: document, options: options)
 	}
 
@@ -99,7 +102,7 @@ private struct HTMLRenderer: MarkupVisitor {
 	mutating func visitText(_ text: Text) {
 		// Body text uses the same escape policy as the legacy parser (only
 		// `&<>`). The full `&<>"` policy is reserved for attribute values.
-		output += escapeHTMLNotQuote(reverseSmartPunctuation(text.string))
+		output += escapeHTMLNotQuote(text.string)
 	}
 
 	mutating func visitEmphasis(_ emphasis: Emphasis) {
@@ -160,7 +163,7 @@ private struct HTMLRenderer: MarkupVisitor {
 		// Walk all descendants so alt text from nested inline formatting
 		// (e.g. `![*diagram*](img.png)` or `![link [label]](...)`) is
 		// preserved rather than silently dropped.
-		let alt = reverseSmartPunctuation(swiftMarkdownPlainText(of: image))
+		let alt = swiftMarkdownPlainText(of: image)
 		output += "<img src=\"\(escapeAttribute(src))\" alt=\"\(escapeAttribute(alt))\">"
 	}
 
@@ -374,7 +377,7 @@ private struct HTMLRenderer: MarkupVisitor {
 						output += "</p>"
 					} else {
 						output += "<p>"
-						output += escapeHTMLNotQuote(reverseSmartPunctuation(stripped))
+						output += escapeHTMLNotQuote(stripped)
 						for tail in inlineChildren.dropFirst() { visit(tail) }
 						output += "</p>"
 					}
@@ -429,33 +432,4 @@ private struct HTMLRenderer: MarkupVisitor {
 		escapeHTML(string)
 	}
 
-	/// Undoes cmark-gfm's smart-punctuation transformations so output matches
-	/// the literal source. The legacy parser doesn't perform any typographic
-	/// substitution; we keep that behavior.
-	private func reverseSmartPunctuation(_ string: String) -> String {
-		guard string.contains(where: { isSmartCharacter($0) }) else { return string }
-		var result = ""
-		result.reserveCapacity(string.count)
-		for character in string {
-			switch character {
-			case "\u{2018}", "\u{2019}": result.append("'")  // ‘ ’
-			case "\u{201C}", "\u{201D}": result.append("\"") // “ ”
-			case "\u{2013}": result.append("--")              // –
-			case "\u{2014}": result.append("---")             // —
-			case "\u{2026}": result.append("...")             // …
-			default: result.append(character)
-			}
-		}
-		return result
-	}
-
-	private func isSmartCharacter(_ character: Character) -> Bool {
-		switch character {
-		case "\u{2018}", "\u{2019}", "\u{201C}", "\u{201D}",
-			 "\u{2013}", "\u{2014}", "\u{2026}":
-			return true
-		default:
-			return false
-		}
-	}
 }

--- a/Sources/SwiftTextPages/MarkdownToPages.swift
+++ b/Sources/SwiftTextPages/MarkdownToPages.swift
@@ -57,7 +57,7 @@ enum MarkdownPagesBuilder {
 		// Footnote definitions (`[^id]: …`) aren't parsed by swift-markdown — extract them
 		// (and strip them from the source) so `[^id]` references can become real footnotes.
 		let (cleaned, definitions) = extractFootnoteDefinitions(markdown)
-		let document = Document(parsing: cleaned, options: [])
+		let document = Document(parsing: cleaned, options: [.disableSmartOpts])
 		var visitor = BlockVisitor()
 		visitor.footnoteDefinitions = definitions
 		visitor.visit(document)
@@ -123,7 +123,7 @@ private struct InlineCollector {
 	private mutating func visit(_ markup: Markup) {
 		switch markup {
 		case let text as Text:
-			appendText(reverseSmartPunct(text.string))
+			appendText(text.string)
 		case let emphasis as Emphasis:
 			withStyle({ $0.italic = true }) { $0.collect(from: emphasis) }
 		case let strong as Strong:
@@ -145,7 +145,7 @@ private struct InlineCollector {
 			}
 		case let image as Image:
 			// Match the DOCX writer: images become italic placeholder text.
-			let alt = reverseSmartPunct(swiftMarkdownPlainText(of: image))
+			let alt = swiftMarkdownPlainText(of: image)
 			var imageStyle = style
 			imageStyle.italic = true
 			append(alt.isEmpty ? "[image]" : alt, style: imageStyle)
@@ -229,7 +229,7 @@ private struct BlockVisitor: MarkupVisitor {
 			paragraphs.append(BodyParagraph(
 				text: "\u{FFFC}",
 				paragraphStyle: PagesStyleID.body,
-				image: BodyParagraph.ImageRef(source: source, alt: reverseSmartPunct(swiftMarkdownPlainText(of: image)))
+				image: BodyParagraph.ImageRef(source: source, alt: swiftMarkdownPlainText(of: image))
 			))
 			return
 		}
@@ -402,30 +402,3 @@ private struct BlockVisitor: MarkupVisitor {
 	}
 }
 
-// MARK: - Smart-punctuation reversal (cmark forces it on; undo to match source)
-
-private func reverseSmartPunct(_ string: String) -> String {
-	guard string.contains(where: isSmartCharacter) else { return string }
-	var result = ""
-	result.reserveCapacity(string.count)
-	for character in string {
-		switch character {
-		case "\u{2018}", "\u{2019}": result.append("'")
-		case "\u{201C}", "\u{201D}": result.append("\"")
-		case "\u{2013}": result.append("--")
-		case "\u{2014}": result.append("---")
-		case "\u{2026}": result.append("...")
-		default: result.append(character)
-		}
-	}
-	return result
-}
-
-private func isSmartCharacter(_ character: Character) -> Bool {
-	switch character {
-	case "\u{2018}", "\u{2019}", "\u{201C}", "\u{201D}", "\u{2013}", "\u{2014}", "\u{2026}":
-		return true
-	default:
-		return false
-	}
-}

--- a/Sources/SwiftTextPages/MarkdownToPages.swift
+++ b/Sources/SwiftTextPages/MarkdownToPages.swift
@@ -401,4 +401,3 @@ private struct BlockVisitor: MarkupVisitor {
 		}
 	}
 }
-

--- a/Sources/SwiftTextPages/PagesMarkdownAST.swift
+++ b/Sources/SwiftTextPages/PagesMarkdownAST.swift
@@ -82,7 +82,7 @@ extension PagesDocument {
 	/// block). Multiple blocks (shouldn't occur for one paragraph) join with soft breaks.
 	static func inlineChildren(parsing markdown: String) -> [InlineMarkup] {
 		guard !markdown.isEmpty else { return [] }
-		let document = Document(parsing: markdown, options: [])
+		let document = Document(parsing: markdown, options: [.disableSmartOpts])
 		var result = [InlineMarkup]()
 		for block in document.children {
 			let inlines = block.children.compactMap { $0 as? InlineMarkup }

--- a/Tests/SwiftTextAttributedStringTests/MarkdownAttributedStringRendererTests.swift
+++ b/Tests/SwiftTextAttributedStringTests/MarkdownAttributedStringRendererTests.swift
@@ -304,7 +304,7 @@ struct MarkdownAttributedStringRendererTests {
 
 	// MARK: Smart punctuation
 
-	@Test func smartPunctuationReversedByDefault() {
+	@Test func smartPunctuationNotAppliedByDefault() {
 		let string = wholeString(render("\"q\" a---b"))
 		#expect(!string.contains("\u{201C}"))
 		#expect(!string.contains("\u{2014}"))
@@ -315,6 +315,13 @@ struct MarkdownAttributedStringRendererTests {
 	@Test func smartPunctuationPreservedWithOption() {
 		let string = wholeString(render("\"q\"", .preserveSmartPunctuation))
 		#expect(string.contains("\u{201C}") || string.contains("\u{201D}"))
+	}
+
+	@Test func literalTypographicCharactersSurviveByDefault() {
+		// Real Unicode em/en dashes, ellipsis, and curly quotes already present in
+		// the source must not be mangled into their ASCII spellings (issue #38).
+		let string = wholeString(render("a — b – c… “quoted” ‘single’"))
+		#expect(string == "a — b – c… “quoted” ‘single’")
 	}
 
 	// MARK: Entry points

--- a/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
@@ -133,6 +133,13 @@ struct DocxWriterTests {
 		#expect(runs[5].code == true)
 	}
 
+	@Test("Literal typographic characters already in the source survive unchanged (issue #38)")
+	func inlineParserPreservesLiteralTypographicCharacters() {
+		let runs = MarkdownToDocx.parseInline("a — b – c… “quoted” ‘single’")
+		#expect(runs.count == 1)
+		#expect(runs[0].text == "a — b – c… “quoted” ‘single’")
+	}
+
 	@Test("Inline parser handles links")
 	func inlineParserLinks() {
 		let runs = MarkdownToDocx.parseInline("See [here](https://example.com) for details")

--- a/Tests/SwiftTextMarkdownTests/SwiftMarkdownHTMLRendererTests.swift
+++ b/Tests/SwiftTextMarkdownTests/SwiftMarkdownHTMLRendererTests.swift
@@ -176,4 +176,19 @@ struct SwiftMarkdownHTMLRendererTests {
 		#expect(mixed.contains("a &lt; b"))
 		#expect(mixed.contains("<sub>x</sub>"))
 	}
+
+	@Test func literalTypographicCharactersSurviveUnchanged() {
+		// Real Unicode em/en dashes, ellipsis, and curly quotes already present in
+		// the source must not be mangled into their ASCII spellings (issue #38).
+		let html = SwiftMarkdownHTMLRenderer.convert("a — b – c… “quoted” ‘single’")
+		#expect(html == "<p>a — b – c… “quoted” ‘single’</p>")
+	}
+
+	@Test func asciiSmartPunctuationConventionsStayLiteral() {
+		// cmark-gfm's smart-punctuation substitution is disabled, so typed `--`/
+		// `---`/`...`/straight quotes are left exactly as typed rather than being
+		// smart-substituted and reversed.
+		let html = SwiftMarkdownHTMLRenderer.convert(#"a -- b --- c ... "quoted""#)
+		#expect(html == ##"<p>a -- b --- c ... "quoted"</p>"##)
+	}
 }

--- a/Tests/SwiftTextPagesTests/MarkdownToPagesTests.swift
+++ b/Tests/SwiftTextPagesTests/MarkdownToPagesTests.swift
@@ -323,4 +323,15 @@ struct MarkdownToPagesTests {
 		let urlField = hyperlinks.first.flatMap { ProtobufMessage($0.payload).bytes(2) }
 		#expect(urlField.map { String(decoding: $0, as: UTF8.self) } == "https://www.cocoanetics.com")
 	}
+
+	@Test("Literal typographic characters already in the source survive unchanged (issue #38)")
+	func literalTypographicCharactersSurvive() throws {
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("swifttext-smartpunct-\(UUID().uuidString).pages")
+		defer { try? FileManager.default.removeItem(at: url) }
+		try MarkdownToPages.convert("a — b – c… “quoted” ‘single’", to: url)
+
+		let text = try PagesFile(url: url).plainText()
+		#expect(text.contains("a — b – c… “quoted” ‘single’"))
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #38.

`SwiftMarkdownHTMLRenderer` reversed cmark-gfm's smart-punctuation substitution after parsing (converting `— – … ‘ ’ “ ”` back to `--`/`---`/`...`/straight quotes) to keep output byte-identical to the literal source. The same pattern was duplicated in three other renderers (Pages, DOCX, AttributedString).

The problem: by the time the renderer visits the AST's text nodes, there's no way to tell "cmark smart-substituted this from `---`" apart from "the author typed a real em dash directly" — both are just a `Text` node holding the same Unicode character. The blanket reversal destroyed real typographic characters already present in the source (pasted prose, editors with autocorrect, etc.) — e.g. every em dash in an 89k-word manuscript came out as `---`.

## Fix

Parse with `.disableSmartOpts` so cmark never performs the ASCII→typographic substitution in the first place — nothing to reverse, and literal typographic input is never touched. Applied consistently across all parse call sites:

- `SwiftMarkdownHTMLRenderer` — deleted `reverseSmartPunctuation`/`isSmartCharacter`
- `MarkdownFootnoteRenderer` — its two parse sites (feeds the HTML renderer's `document:` entry point)
- `MarkdownToPages` — deleted the duplicated reversal helpers
- `MarkdownDocxBuilder` — same duplicated pair, deleted
- `MarkdownAttributedStringRenderer` — its opt-in `.preserveSmartPunctuation` flag (for callers who *want* the ASCII→typographic upgrade, e.g. nicer display typography) now skips `.disableSmartOpts` on that path instead of reversing; the default path gets `.disableSmartOpts` and no reversal
- `PagesMarkdownAST` — one-line consistency fix on the pages→markdown direction, which also feeds these renderers

Net effect: 76 lines added, 147 removed — the reversal logic is gone, not just patched.

## Test plan

- [x] Reproduced the exact repro from #38 (`echo "a — b… c" | swifttext render --stdin -o out.html`) — em dash and ellipsis now survive unchanged in the output
- [x] Verified typed ASCII conventions (`--`, `---`, `...`, straight quotes) still come out literally, since smart substitution never happens
- [x] Added 5 regression tests (HTML, AttributedString, Pages, DOCX) asserting literal typographic characters survive unchanged
- [x] Full targeted test run: 198 passed, 0 failed (`SwiftTextMarkdownTests`, `SwiftTextAttributedStringTests`, `SwiftTextDOCXTests`, `SwiftTextPagesTests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)