### PR TITLE
Add CSS Paged Media margin boxes to the swift render engine

### DIFF
--- a/Docs/RENDER_ENGINE.md
+++ b/Docs/RENDER_ENGINE.md
@@ -98,10 +98,16 @@ metrics — no embedding needed.
 - `text-decoration` underline / line-through.
 - Lists (`<ul>`/`<ol>` markers), clickable links (`<a href>` → PDF annotations).
 - Pagination to a fixed page size; embedded `<style>` and caller CSS.
+- `@page { size; margin }`, plus CSS Paged Media margin boxes: `@top-left/
+  -center/-right` and `@bottom-left/-center/-right` for running headers/
+  footers, with `content` as a literal string or `counter(page)`/
+  `counter(pages)` (optionally styled, e.g. `counter(page, upper-roman)`), and
+  the `:first`/`:left`/`:right` page selectors (e.g. to suppress a header on
+  the title page via `@page :first { @top-center { content: normal } }`).
 
 ## Not yet (roadmap)
 
 Images (`<img>`), tables, fl/grid, floats, positioned boxes, parent/child margin
 collapsing, transforms, gradients, SVG, bidi/complex-script shaping, hyphenation,
-`@page` rules, bookmarks/outline. See the layout source for the simplifications
-called out in comments.
+bookmarks/outline. See the layout source for the simplifications called out in
+comments.

--- a/Sources/SwiftTextCSS/StyleResolver.swift
+++ b/Sources/SwiftTextCSS/StyleResolver.swift
@@ -155,6 +155,36 @@ public final class StyleResolver {
 	}
 }
 
+/// Resolve a flat declaration list (no selector cascade — the last declared
+/// longhand wins) against a `ComputedStyle` that inherits from `parent`.
+///
+/// Used where a style is needed without an element to cascade for, e.g. CSS
+/// Paged Media `@page` margin boxes (running headers/footers, page numbers).
+public func applyDeclarations(_ declarations: [Declaration], inheriting parent: ComputedStyle, rootFontSize: Double) -> ComputedStyle {
+	var style = ComputedStyle.inheriting(from: parent)
+	var winners: [String: [ComponentValue]] = [:]
+	for declaration in declarations {
+		for longhand in expand(declaration) {
+			winners[longhand.name] = longhand.value
+		}
+	}
+
+	// font-size first: em/ex units in other properties resolve against it.
+	if let value = winners["font-size"] {
+		applyLonghand("font-size", value, to: &style, parent: parent, rootFontSize: rootFontSize)
+	}
+	// color next: `currentColor` in other properties resolves to it.
+	if let value = winners["color"] {
+		applyLonghand("color", value, to: &style, parent: parent, rootFontSize: rootFontSize)
+	}
+	style.borderColor = Edges(style.color)
+
+	for (name, value) in winners where name != "font-size" && name != "color" {
+		applyLonghand(name, value, to: &style, parent: parent, rootFontSize: rootFontSize)
+	}
+	return style
+}
+
 // MARK: - Shorthand expansion
 
 private func significant(_ value: [ComponentValue]) -> [ComponentValue] {

--- a/Sources/SwiftTextRender/BoxTreeBuilder.swift
+++ b/Sources/SwiftTextRender/BoxTreeBuilder.swift
@@ -68,7 +68,9 @@ public enum BoxTreeBuilder {
 		return ordinal
 	}
 
-	private static func formatOrdinal(_ number: Int, as type: ListStyleType) -> String {
+	/// Format a 1-based ordinal per a `list-style-type`-like keyword. Also used
+	/// to render `@page` margin-box `counter(page, <style>)` values.
+	static func formatOrdinal(_ number: Int, as type: ListStyleType) -> String {
 		switch type {
 		case .lowerAlpha: return alphabetic(number, uppercase: false)
 		case .upperAlpha: return alphabetic(number, uppercase: true)

--- a/Sources/SwiftTextRender/HTMLRenderer.swift
+++ b/Sources/SwiftTextRender/HTMLRenderer.swift
@@ -72,6 +72,7 @@ public enum HTMLRenderer {
 		// @page rules in the document override the page geometry.
 		var options = options
 		applyAtPageRules(documentSheets + css, to: &options)
+		let pageRules = parsePageRules(documentSheets + css)
 
 		// Resolve the base direction (auto-detect from content for Markdown etc.).
 		let baseDirection: Direction
@@ -97,11 +98,17 @@ public enum HTMLRenderer {
 		let pdf = PDF()
 		let fontBuilder = FontResourceBuilder(pdf: pdf)
 		var pageObjects: [PDFDictionary] = []
-		for slice in slices {
+		let totalPages = slices.count
+		for (pageIndex, slice) in slices.enumerated() {
 			let geometry = PageGeometry(pageWidthPx: options.pageWidthPx, pageHeightPx: pageHeightPx,
 			                            marginPx: margin, columnTop: slice.top, sliceHeightPx: slice.bottom - slice.top)
 			let painter = Painter(geometry: geometry, fonts: fonts, builder: fontBuilder)
 			painter.paint(rootBox)
+			if !pageRules.isEmpty {
+				let marginBoxes = resolveMarginBoxes(pageRules, pageIndex: pageIndex, totalPages: totalPages,
+				                                     rootStyle: rootBox.style, rootFontSize: rootBox.style.fontSize)
+				painter.paintMarginBoxes(marginBoxes)
+			}
 			pdf.addObject(painter.stream)
 			let page = PDFDictionary([
 				("Type", "/Page"),

--- a/Sources/SwiftTextRender/PageMarginBoxes.swift
+++ b/Sources/SwiftTextRender/PageMarginBoxes.swift
@@ -1,0 +1,199 @@
+//  PageMarginBoxes.swift
+//  SwiftTextRender
+//
+//  CSS Paged Media margin boxes: `@page { @top-center { content: ... } }` and
+//  friends, for running headers/footers and `counter(page)`/`counter(pages)`
+//  page numbers. Parsing collects the six side (non-corner) margin boxes;
+//  resolution turns them into plain text + style, ready for `Painter` to draw
+//  directly in page space once the final page count is known.
+
+import Foundation
+import SwiftTextCSS
+
+/// The CSS Paged Media margin boxes this engine supports (the three per edge
+/// on the top and bottom edges; corners and the left/right edges are not).
+enum MarginBoxArea: String, CaseIterable {
+	case topLeft = "top-left"
+	case topCenter = "top-center"
+	case topRight = "top-right"
+	case bottomLeft = "bottom-left"
+	case bottomCenter = "bottom-center"
+	case bottomRight = "bottom-right"
+
+	var isTop: Bool {
+		switch self {
+		case .topLeft, .topCenter, .topRight: return true
+		case .bottomLeft, .bottomCenter, .bottomRight: return false
+		}
+	}
+
+	/// The alignment implied by the box's position, absent an explicit
+	/// `text-align` in the rule.
+	var impliedTextAlign: TextAlign {
+		switch self {
+		case .topLeft, .bottomLeft: return .left
+		case .topCenter, .bottomCenter: return .center
+		case .topRight, .bottomRight: return .right
+		}
+	}
+}
+
+/// A `@page` pseudo-class selector: `:first`, `:left`, `:right`. Anything else
+/// (`:blank`, named pages) is recognized but never matches — safer than
+/// silently applying an unsupported rule to every page.
+struct PageSelector {
+	var first = false
+	var side: String? // "left" or "right"
+	var unsupported = false
+
+	func matches(pageIndex: Int) -> Bool {
+		if unsupported { return false }
+		if first, pageIndex != 0 { return false }
+		if let side {
+			let isRightPage = pageIndex.isMultiple(of: 2) // page 1 (index 0) is recto/right
+			if (side == "right") != isRightPage { return false }
+		}
+		return true
+	}
+}
+
+/// One `@page` rule's margin-box declarations, keyed by box name, plus the
+/// selector that decides which pages it applies to.
+struct PageRule {
+	let selector: PageSelector
+	let marginBoxes: [MarginBoxArea: [Declaration]]
+}
+
+/// A margin box resolved for a specific page: literal display text (counters
+/// already substituted) and the style to paint it with.
+struct ResolvedMarginBox {
+	let area: MarginBoxArea
+	let text: String
+	let style: ComputedStyle
+}
+
+// MARK: - Parsing
+
+/// Collect every `@page` rule's margin-box declarations across `sheets`.
+/// Rules with no margin boxes (only `size`/`margin`) are skipped — those are
+/// handled separately for page geometry.
+func parsePageRules(_ sheets: [String]) -> [PageRule] {
+	var rules: [PageRule] = []
+	for sheet in sheets {
+		for node in parseStylesheet(sheet, skipComments: true, skipWhitespace: true) {
+			guard case .atRule(let atRule) = node, atRule.lowerAtKeyword == "page", let content = atRule.content else { continue }
+			var marginBoxes: [MarginBoxArea: [Declaration]] = [:]
+			for child in parseBlocksContents(content, skipComments: true, skipWhitespace: true) {
+				guard case .atRule(let nested) = child,
+				      let area = MarginBoxArea(rawValue: nested.lowerAtKeyword),
+				      let nestedContent = nested.content else { continue }
+				marginBoxes[area, default: []].append(contentsOf: parseDeclarations(nestedContent))
+			}
+			guard !marginBoxes.isEmpty else { continue }
+			rules.append(PageRule(selector: parsePageSelector(atRule.prelude), marginBoxes: marginBoxes))
+		}
+	}
+	return rules
+}
+
+private func parsePageSelector(_ prelude: [ComponentValue]) -> PageSelector {
+	var selector = PageSelector()
+	let tokens = prelude.filter { !$0.isWhitespaceOrComment }
+	var index = 0
+	while index < tokens.count {
+		if tokens[index].isLiteral(":"), index + 1 < tokens.count, case .ident(let ident) = tokens[index + 1].token {
+			switch ident.lowercased() {
+			case "first": selector.first = true
+			case "left", "right": selector.side = ident.lowercased()
+			default: selector.unsupported = true // e.g. :blank
+			}
+			index += 2
+		} else {
+			selector.unsupported = true // e.g. a named page
+			index += 1
+		}
+	}
+	return selector
+}
+
+/// One piece of a margin box's `content` value.
+private enum ContentPart {
+	case literal(String)
+	case pageCounter(style: ListStyleType)
+	case pagesCounter(style: ListStyleType)
+}
+
+/// Parse a `content` value into literal/counter parts. `normal`/`none` (the
+/// default — no box is generated) and unparseable values both yield `[]`.
+private func parseContentValue(_ value: [ComponentValue]) -> [ContentPart] {
+	let tokens = value.filter { !$0.isWhitespaceOrComment }
+	guard !tokens.isEmpty else { return [] }
+	if tokens.count == 1, case .ident(let ident) = tokens[0].token, ["normal", "none"].contains(ident.lowercased()) {
+		return []
+	}
+
+	var parts: [ContentPart] = []
+	for token in tokens {
+		switch token.token {
+		case .string(let string):
+			parts.append(.literal(string))
+		case .function(let name, let arguments) where name.lowercased() == "counter":
+			let args = arguments.filter { !$0.isWhitespaceOrComment && !$0.isLiteral(",") }
+			guard let first = args.first, case .ident(let counterName) = first.token else { continue }
+			var style = ListStyleType.decimal
+			if args.count > 1, case .ident(let styleName) = args[1].token, let parsed = ListStyleType(rawValue: styleName.lowercased()) {
+				style = parsed
+			}
+			switch counterName.lowercased() {
+			case "page": parts.append(.pageCounter(style: style))
+			case "pages": parts.append(.pagesCounter(style: style))
+			default: break // other named counters aren't tracked by this engine
+			}
+		default:
+			break // attr(), url(), quotes, etc. — not supported
+		}
+	}
+	return parts
+}
+
+private func renderedText(_ parts: [ContentPart], pageIndex: Int, totalPages: Int) -> String {
+	parts.map { part in
+		switch part {
+		case .literal(let string): return string
+		case .pageCounter(let style): return BoxTreeBuilder.formatOrdinal(pageIndex + 1, as: style)
+		case .pagesCounter(let style): return BoxTreeBuilder.formatOrdinal(totalPages, as: style)
+		}
+	}.joined()
+}
+
+// MARK: - Resolution
+
+/// Resolve every margin box that applies to page `pageIndex` (0-based), given
+/// the final page count. Declarations from every matching rule are merged per
+/// box, in source order, so an unqualified base rule and a later `:first`
+/// override can each set only the properties they care about (e.g. `:first`
+/// clearing `content` while the base rule's `font-size` still applies).
+func resolveMarginBoxes(_ rules: [PageRule], pageIndex: Int, totalPages: Int, rootStyle: ComputedStyle, rootFontSize: Double) -> [ResolvedMarginBox] {
+	let matching = rules.filter { $0.selector.matches(pageIndex: pageIndex) }
+	guard !matching.isEmpty else { return [] }
+
+	var result: [ResolvedMarginBox] = []
+	for area in MarginBoxArea.allCases {
+		let declarations = matching.flatMap { $0.marginBoxes[area] ?? [] }
+		guard let contentDeclaration = declarations.last(where: { $0.lowerName == "content" }) else { continue }
+		let parts = parseContentValue(contentDeclaration.value)
+		guard !parts.isEmpty else { continue }
+		let text = renderedText(parts, pageIndex: pageIndex, totalPages: totalPages)
+		guard !text.isEmpty else { continue }
+
+		// The box's own parent for inheritance: the document root's style (per
+		// spec, margin boxes inherit from the page context, not the element
+		// under the cursor), with its position's implied alignment as the
+		// default `text-align` — an explicit `text-align` in the rule still wins.
+		var parent = rootStyle
+		parent.textAlign = area.impliedTextAlign
+		let style = applyDeclarations(declarations.filter { $0.lowerName != "content" }, inheriting: parent, rootFontSize: rootFontSize)
+		result.append(ResolvedMarginBox(area: area, text: text, style: style))
+	}
+	return result
+}

--- a/Sources/SwiftTextRender/Painter.swift
+++ b/Sources/SwiftTextRender/Painter.swift
@@ -47,6 +47,10 @@ public final class Painter {
 		self.builder = builder
 		// Map CSS px (y-down) to PDF pt (y-up) for the whole page.
 		stream.setMatrix(pxToPt, 0, 0, pxToPt, 0, 0)
+		// Save this (unclipped) state so margin-box painting can later restore
+		// it: the clip below must not apply there, since margin boxes live
+		// outside the content slice, in the page's margin area.
+		stream.pushState()
 		// Clip to this page's content slice so other pages don't bleed in.
 		let contentWidth = geometry.pageWidthPx - 2 * geometry.marginPx
 		stream.rectangle(geometry.marginPx,
@@ -152,6 +156,55 @@ public final class Painter {
 			stream.fill()
 		}
 		stream.popState()
+	}
+
+	// MARK: - @page margin boxes
+
+	/// Paint resolved `@page` margin-box content (running headers/footers,
+	/// page-number counters) directly in page space, independent of the
+	/// column-to-slice mapping used for body content: margin boxes sit in the
+	/// fixed page-margin strip, not on the scrolling column.
+	func paintMarginBoxes(_ boxes: [ResolvedMarginBox]) {
+		guard !boxes.isEmpty else { return }
+		// Restore the state saved in `init`, before the content-slice clip.
+		stream.popState()
+		for box in boxes {
+			let font = fonts.font(for: box.style)
+			let resource = builder.resourceName(for: font)
+			let textWidth = font.width(of: box.text, size: box.style.fontSize)
+			let ascent = font.ascent(size: box.style.fontSize)
+			let descent = font.descent(size: box.style.fontSize)
+
+			let contentWidth = geometry.pageWidthPx - 2 * geometry.marginPx
+			let extra = max(0, contentWidth - textWidth)
+			let rtl = box.style.direction == .rtl
+			let x: Double
+			switch box.style.textAlign {
+			case .center: x = geometry.marginPx + extra / 2
+			case .right: x = geometry.marginPx + extra
+			case .left: x = geometry.marginPx
+			case .end: x = geometry.marginPx + (rtl ? 0 : extra)
+			case .start: x = geometry.marginPx + (rtl ? extra : 0)
+			case .justify: x = geometry.marginPx
+			}
+
+			// Center the text vertically within its margin strip (top strip is
+			// [0, marginPx]; bottom strip is [pageHeightPx - marginPx, pageHeightPx]).
+			let stripTop = box.area.isTop ? 0 : geometry.pageHeightPx - geometry.marginPx
+			let baselineY = stripTop + (geometry.marginPx + ascent - descent) / 2
+
+			stream.beginText()
+			stream.setColorRGB(box.style.color.red, box.style.color.green, box.style.color.blue)
+			stream.setFontSize(resource, box.style.fontSize)
+			stream.moveTextTo(x, geometry.pageHeightPx - baselineY)
+			switch font {
+			case .standard:
+				stream.showRawString(encodeWinAnsi(box.text))
+			case .embedded(let embedded):
+				stream.showHexString(encodeGlyphs(box.text, font: embedded, fontKey: font.key))
+			}
+			stream.endText()
+		}
 	}
 
 	// MARK: - Text

--- a/Tests/SwiftTextRenderTests/RenderPDFTests.swift
+++ b/Tests/SwiftTextRenderTests/RenderPDFTests.swift
@@ -567,6 +567,109 @@ struct RenderPDFTests {
 		#endif
 	}
 
+	// MARK: - @page margin boxes
+
+	@Test("@top-center content renders as a running header")
+	func marginBoxContent() async throws {
+		let html = """
+		<style>@page { @top-center { content: "The Shattered Skies"; font-style: italic; font-size: 8.5pt } }</style>
+		<p>Body text.</p>
+		"""
+		let data = try await HTMLRenderer.renderPDF(html: html)
+		#if canImport(PDFKit)
+		let document = try #require(PDFDocument(data: data))
+		let text = document.page(at: 0)?.string ?? ""
+		#expect(text.contains("The Shattered Skies"))
+		#endif
+	}
+
+	@Test("counter(page)/counter(pages) number every page")
+	func marginBoxPageCounters() async throws {
+		var html = "<style>@page { @bottom-center { content: \"Page \" counter(page) \" of \" counter(pages) } }</style><body>"
+		for index in 0 ..< 120 {
+			html += "<p>Paragraph number \(index): a line of text to fill the page.</p>"
+		}
+		html += "</body>"
+		let data = try await HTMLRenderer.renderPDF(html: html)
+		#if canImport(PDFKit)
+		let document = try #require(PDFDocument(data: data))
+		let pageCount = document.pageCount
+		#expect(pageCount > 1)
+		let firstText = document.page(at: 0)?.string ?? ""
+		#expect(firstText.contains("Page 1 of \(pageCount)"))
+		let lastText = document.page(at: pageCount - 1)?.string ?? ""
+		#expect(lastText.contains("Page \(pageCount) of \(pageCount)"))
+		#endif
+	}
+
+	#if canImport(AppKit) && canImport(PDFKit)
+	@Test("Margin-box content actually paints (regression: must escape the content-area clip)")
+	func marginBoxIsNotClipped() async throws {
+		// A large, distinctive header: text-presence checks alone wouldn't catch
+		// the margin box being silently clipped away by the content-slice clip
+		// that `Painter.init` sets up for body painting (margin boxes live
+		// outside that slice, in the page's margin area) — only the rendered
+		// raster can. Regression test for that bug.
+		let pdf = try await HTMLRenderer.renderPDF(html: """
+		<style>@page { margin: 100px; @top-center { content: "HEADERTEXT"; font-size: 40px } }</style>
+		<p>Body</p>
+		""")
+		let document = try #require(PDFDocument(data: pdf))
+		let page = try #require(document.page(at: 0))
+		let bounds = page.bounds(for: .mediaBox)
+
+		let image = NSImage(size: bounds.size)
+		image.lockFocus()
+		NSColor.white.setFill()
+		NSRect(origin: .zero, size: bounds.size).fill()
+		if let ctx = NSGraphicsContext.current?.cgContext {
+			page.draw(with: .mediaBox, to: ctx)
+		}
+		image.unlockFocus()
+		let tiff = try #require(image.tiffRepresentation)
+		let bitmap = try #require(NSBitmapImageRep(data: tiff))
+
+		// The margin (100px == 75pt) strip is the top ~75pt of the page, in a
+		// top-left-origin, y-down bitmap. Scan a band well inside it for any
+		// non-white pixel — the header glyphs, if not clipped away.
+		var foundInk = false
+		for y in 10 ... min(60, Int(bounds.height) - 1) where !foundInk {
+			for x in stride(from: 0, to: Int(bounds.width), by: 2) {
+				guard let color = bitmap.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else { continue }
+				if color.redComponent < 0.9 || color.greenComponent < 0.9 || color.blueComponent < 0.9 {
+					foundInk = true
+					break
+				}
+			}
+		}
+		#expect(foundInk)
+	}
+	#endif
+
+	@Test("@page :first suppresses the running header on page one only")
+	func marginBoxFirstPageOverride() async throws {
+		var html = """
+		<style>
+		@page { @top-center { content: "Running Title" } }
+		@page :first { @top-center { content: normal } }
+		</style>
+		<body>
+		"""
+		for index in 0 ..< 120 {
+			html += "<p>Paragraph number \(index): a line of text to fill the page.</p>"
+		}
+		html += "</body>"
+		let data = try await HTMLRenderer.renderPDF(html: html)
+		#if canImport(PDFKit)
+		let document = try #require(PDFDocument(data: data))
+		#expect(document.pageCount > 1)
+		let firstText = document.page(at: 0)?.string ?? ""
+		#expect(!firstText.contains("Running Title"))
+		let secondText = document.page(at: 1)?.string ?? ""
+		#expect(secondText.contains("Running Title"))
+		#endif
+	}
+
 	// MARK: - Sample artifact
 
 	@Test("Generates a sample PDF artifact")


### PR DESCRIPTION
## Summary

- Closes #39. Extends the `swift` engine's `@page` rule parser to collect the six side margin boxes — `@top-left/-center/-right` and `@bottom-left/-center/-right` — with `content` as a literal string or `counter(page)`/`counter(pages)` (optionally styled, e.g. `counter(page, upper-roman)`), plus the `:first`/`:left`/`:right` page selectors. This is enough to render running headers/footers and auto page numbers, suppressed on a title page via `@page :first { @top-center { content: normal } }`.
- `swifttext pdf`/`swifttext render --engine swift` pick this up directly since they share the same PDF machinery.
- Fixes a latent `Painter` bug this surfaced: the content-area clip set up in `Painter.init` for body painting was never popped, so margin-box text (drawn after body content, in the page's margin area) was silently clipped away. Text-extraction-based tests didn't catch it (PDF text extraction ignores clip paths) — only rendering the page to a bitmap did. `Painter` now saves the pre-clip state and restores it before painting margin boxes; added a pixel-level regression test for this specifically.
- Small new public API on `SwiftTextCSS` (`applyDeclarations`) to resolve a flat declaration list against a style without an element to cascade for — reused by the margin-box style resolution.
- Updated `Docs/RENDER_ENGINE.md`.

## Test plan

- [x] `swift test` — 452 tests pass (3 new: content rendering, `counter(page)`/`counter(pages)`, `:first` suppression; 1 pixel-level regression test for the clip bug, verified to fail without the fix and pass with it).
- [x] `swiftlint lint` clean on all touched files.
- [x] Manually built the exact manuscript example from the issue via `swifttext pdf --engine swift` and visually confirmed: title page has no header/footer, subsequent pages show the italic running title and correct page number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)