### PR TITLE
Markdown → EPUB 3 export (#41), plus an O(n²) fix for the swift PDF engine

### DIFF
--- a/Docs/EPUB.md
+++ b/Docs/EPUB.md
@@ -1,0 +1,89 @@
+# Markdown → EPUB export
+
+`SwiftTextEPUB` turns a Markdown manuscript (plus a cover image and metadata)
+into a valid **EPUB 3** publication — the native equivalent of reaching for
+`pandoc -o book.epub`. Output validates cleanly under
+[`epubcheck`](https://www.w3.org/publishing/epubcheck/) (EPUB 3.3 rules).
+
+It follows the same shape as `SwiftTextDOCX`/`SwiftTextPages`: walk the
+swift-markdown AST, build the format's files, and zip them into the container.
+
+## CLI
+
+```bash
+swifttext render manuscript.md -o book.epub \
+  --title "The Shattered Skies" \
+  --author "Elise Kummer" \
+  --language en \
+  --chapter-level h2 \
+  --cover cover.jpg \
+  --css house-style.css
+```
+
+- **`--chapter-level h1…h6`** — a new chapter file begins at every heading of
+  this level (default `h1`). Content before the first such heading becomes a
+  front-matter section (kept out of the table of contents). A chapter's TOC
+  label is its run of leading consecutive headings joined with `": "`, so a
+  `## 1` immediately followed by `### The Birthday…` reads as
+  *“1: The Birthday…”* in the navigation while both headings still show in the
+  chapter body.
+- **`--cover <image>`** — JPEG/PNG/GIF/WebP/SVG. Embedded as the OPF
+  `cover-image`, wrapped in an aspect-fit SVG so it fills the screen. Apple
+  Books wants a cover at least 1400px wide.
+- **`--title` / `--author` (repeatable) / `--language`** — Dublin Core
+  metadata. The title defaults to the document's first heading, then the input
+  filename.
+- **`--css <file>`** — a shared stylesheet flag that also applies to `html` and
+  `pdf` output. For EPUB it is appended after the bundled reading stylesheet
+  (so author rules win) and referenced from every content document — e.g. to
+  swap the default scene-break rule for custom artwork.
+
+## Library
+
+```swift
+import SwiftTextEPUB
+
+let metadata = EpubMetadata(
+    title: "The Shattered Skies",
+    authors: ["Elise Kummer"],
+    language: "en",
+    coverImage: try? Data(contentsOf: coverURL),
+    coverImageFilename: "cover.jpg")
+
+try MarkdownToEpub.convert(
+    markdown, to: outputURL, metadata: metadata,
+    options: EpubOptions(chapterLevel: 2, userCSS: nil))
+```
+
+`EpubMetadata`'s `identifier` (a `urn:uuid:` by default) and `modified`
+timestamp default to a fresh UUID and the current time; pass explicit values
+for a reproducible, byte-identical build.
+
+## What it emits
+
+A standard OCF ZIP container:
+
+```
+mimetype                     (first entry, stored — as the spec requires)
+META-INF/container.xml
+OEBPS/content.opf            (OPF 3.0: Dublin Core metadata, manifest, spine)
+OEBPS/nav.xhtml              (EPUB 3 nav: toc + landmarks)
+OEBPS/toc.ncx                (EPUB 2 NCX, for older reading systems)
+OEBPS/styles/stylesheet.css  (bundled reading style + any --css appended)
+OEBPS/images/cover.<ext>     (when a cover is given)
+OEBPS/text/cover.xhtml       (aspect-fit SVG cover page)
+OEBPS/text/titlepage.xhtml   (generated from the metadata)
+OEBPS/text/chNNN.xhtml       (one XHTML content document per chapter)
+```
+
+Chapter bodies are rendered through the Markdown renderer's XHTML mode
+(`SwiftMarkdownHTMLRenderer` with `.xhtml`), so void elements are self-closed
+and the documents parse as well-formed XML rather than lenient HTML5.
+
+## Not yet
+
+Nested (multi-level) tables of contents, per-chapter footnote sections,
+embedding of inline body images referenced by relative path, and custom
+`@font-face` embedding. The first pass targets long-form prose (novels,
+manuscripts), which is what the container, chaptering, cover, and metadata
+above cover.

--- a/Package.swift
+++ b/Package.swift
@@ -106,6 +106,7 @@ let cliTargets: [Target] = [
 		dependencies: [
 			"SwiftTextHTML",
 			"SwiftTextDOCX",
+			"SwiftTextEPUB",
 			"SwiftTextPages",
 			"SwiftTextNumbers",
 			"SwiftTextKeynote",
@@ -202,6 +203,10 @@ let packageProducts: [Product] = [
 		targets: ["SwiftTextDOCX"]
 	),
 	.library(
+		name: "SwiftTextEPUB",
+		targets: ["SwiftTextEPUB"]
+	),
+	.library(
 		name: "SwiftTextPages",
 		targets: ["SwiftTextPages"]
 	),
@@ -279,6 +284,20 @@ let packageTargets: [Target] = [
 		],
 		path: "Sources/SwiftTextDOCX"
 	),
+	.target(
+		name: "SwiftTextEPUB",
+		dependencies: [
+			"SwiftTextMarkdown",
+			.product(name: "Markdown", package: "swift-markdown"),
+			// Same single-trait ZIPFoundation gating as SwiftTextDOCX/SwiftTextPages:
+			// the EPUB container is a Zip archive. The CLI default trait enables EPUB
+			// transitively for a plain `swift build`.
+			.product(name: "ZIPFoundation", package: "ZIPFoundation", condition: .when(traits: ["EPUB"])),
+			// Shared dependency-free utilities (ImageDimensions); see SwiftTextDOCX.
+			"SwiftTextCore"
+		],
+		path: "Sources/SwiftTextEPUB"
+	),
 	// Shared iWork (IWA) read core. Snappy and Protocol Buffers decoding are
 	// implemented in-target; ZIPFoundation (the .iwa container is a Zip archive)
 	// is the only external dependency, gated by PAGES with the same single-trait
@@ -327,6 +346,11 @@ let packageTargets: [Target] = [
 		resources: [
 			.process("Resources")
 		]
+	),
+	.testTarget(
+		name: "SwiftTextEPUBTests",
+		dependencies: ["SwiftTextEPUB", "SwiftTextMarkdown"],
+		path: "Tests/SwiftTextEPUBTests"
 	),
 	.testTarget(
 		name: "SwiftTextPagesTests",
@@ -409,11 +433,12 @@ let allTraits: Set<Trait> = [
 	.trait(name: "HTML", description: "HTML parsing"),
 	.trait(name: "PDF", description: "PDF text extraction", enabledTraits: ["OCR"]),
 	.trait(name: "DOCX", description: "DOCX extraction"),
+	.trait(name: "EPUB", description: "EPUB generation"),
 	.trait(name: "PAGES", description: "Pages (iWork) extraction"),
 	// CLI enables DOCX, PAGES, and HTML because SwiftTextCLI links
 	// SwiftTextDOCX, SwiftTextPages, and SwiftTextHTML, whose external products
 	// (ZIPFoundation, XMLKit's HTMLParser) are guarded by those traits.
-	.trait(name: "CLI", description: "swifttext command-line tool dependencies", enabledTraits: ["DOCX", "PAGES", "HTML"]),
+	.trait(name: "CLI", description: "swifttext command-line tool dependencies", enabledTraits: ["DOCX", "EPUB", "PAGES", "HTML"]),
 	// "CLI" must be a default trait: the SwiftTextCLI and SwiftTextDOCX targets are
 	// always part of the manifest, so a plain `swift build` needs their external
 	// products (ArgumentParser, ZIPFoundation) active to compile. Consumers that

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ Features:
 - Markdown output with headings, emphasis (bold/italic/strikethrough), lists, and
   footnotes
 
+### SwiftTextEPUB
+
+Builds a valid **EPUB 3** publication from a Markdown manuscript, cover image,
+and metadata — the native equivalent of `pandoc -o book.epub` (output validates
+under `epubcheck`). Splits chapters at a configurable heading level, generates
+the OPF package, EPUB 3 nav + legacy NCX, a title page, and an aspect-fit cover
+page, and packages them with `mimetype` stored first as the OCF spec requires.
+See [Docs/EPUB.md](Docs/EPUB.md).
+
 ### SwiftTextPages
 
 Extracts text and structure from Apple Pages (iWork) documents. The modern
@@ -345,7 +354,7 @@ Options:
 - **numbers** `--markdown`/`-m`, `--html`, `--json`, `--output-path <file>`/`-o`
 - **keynote** `--markdown`/`-m`, `--json`, `--output-path <file>`/`-o`
 - **pdf** `--engine webkit|swift`, `--paper a4|letter`, `--landscape`, `--stdin`, `--output <file>`/`-o`
-- **render** `--format html|pdf|docx|pages`, `--engine webkit|swift`, `--paper`, `--landscape`, `--page-break-before <h1…h6>`, `--package`, `--output <file>`/`-o`
+- **render** `--format html|pdf|docx|pages|epub`, `--engine webkit|swift`, `--paper`, `--landscape`, `--page-break-before <h1…h6>`, `--package`, `--output <file>`/`-o`; EPUB & shared: `--css <file>` (html/pdf/epub), `--cover <image>`, `--title`, `--author` (repeatable), `--language`, `--chapter-level <h1…h6>`
 - **overlay** *(macOS only)* `--output-path <file>`/`-o`, `--dpi <value>`, `--raw`
 
 The `pdf` and `render` commands render via **WebKit** by default on macOS and via
@@ -398,6 +407,14 @@ swifttext keynote --markdown ~/Documents/deck.key
 
 # Render Markdown to PDF with the cross-platform engine (works off macOS)
 swifttext render notes.md -o notes.pdf --engine swift
+
+# Build an EPUB 3 from a Markdown manuscript, with a cover and metadata
+swifttext render book.md -o book.epub \
+  --title "The Shattered Skies" --author "Elise Kummer" \
+  --chapter-level h2 --cover cover.jpg
+
+# Apply a custom stylesheet across HTML, PDF, and EPUB output
+swifttext render book.md -o book.epub --css book.css
 
 # Render an overlay PDF for inspection (macOS only)
 swifttext overlay --dpi 300 ~/Documents/report.pdf

--- a/Sources/SwiftTextCLI/PDFCommand.swift
+++ b/Sources/SwiftTextCLI/PDFCommand.swift
@@ -362,7 +362,7 @@ struct PDF: AsyncParsableCommand {
 
 /// Converts a Markdown string to a self-contained HTML document
 /// styled for print output and with CSS `@page` size directives.
-func markdownToHTML(_ markdown: String, paper: PaperSize, landscape: Bool, pageBreakBefore: HeadingBreakLevel? = nil) -> String {
+func markdownToHTML(_ markdown: String, paper: PaperSize, landscape: Bool, pageBreakBefore: HeadingBreakLevel? = nil, extraCSS: String? = nil) -> String {
 	let orientation = landscape ? "landscape" : "portrait"
 	let pageCSS = "\(paper.cssName) \(orientation)"
 	let body = MarkdownToHTML.convert(markdown)
@@ -512,6 +512,7 @@ func markdownToHTML(_ markdown: String, paper: PaperSize, landscape: Bool, pageB
 	}
 	.footnote-definition p { margin: 0.4em 0; }
 	\(headingBreakCSS)
+	\(extraCSS.map { "\n/* User stylesheet */\n" + $0 } ?? "")
 	</style>
 	</head>
 	<body>

--- a/Sources/SwiftTextCLI/RenderCommand.swift
+++ b/Sources/SwiftTextCLI/RenderCommand.swift
@@ -8,6 +8,7 @@
 import ArgumentParser
 import Foundation
 import SwiftTextDOCX
+import SwiftTextEPUB
 import SwiftTextHTML
 import SwiftTextPages
 import SwiftTextRender
@@ -17,18 +18,23 @@ enum RenderOutputFormat: String, ExpressibleByArgument, CaseIterable {
 	case pdf
 	case docx
 	case pages
+	case epub
 }
 
-/// Heading level before which a page break is forced (PDF/HTML print output).
+/// Heading level before which a page break is forced (PDF/HTML print output),
+/// also reused as the EPUB chapter-split level.
 enum HeadingBreakLevel: String, ExpressibleByArgument, CaseIterable {
 	case h1, h2, h3, h4, h5, h6
+
+	/// The numeric level 1–6.
+	var numericLevel: Int { Int(rawValue.dropFirst()) ?? 1 }
 }
 
 @available(macOS 10.15, macCatalyst 13, iOS 13, tvOS 13, watchOS 6, *)
 struct Render: AsyncParsableCommand {
 	static let configuration = CommandConfiguration(
 		commandName: "render",
-		abstract: "Render a Markdown file to HTML, PDF, DOCX, or Pages. Output format is inferred from -o extension or set via --format."
+		abstract: "Render a Markdown file to HTML, PDF, DOCX, Pages, or EPUB. Output format is inferred from -o extension or set via --format."
 	)
 
 	@Argument(help: "Path to a .md/.markdown file. Omit when using --stdin.")
@@ -37,10 +43,10 @@ struct Render: AsyncParsableCommand {
 	@Flag(name: .long, help: "Read Markdown from standard input instead of a file.")
 	var stdin: Bool = false
 
-	@Option(name: .shortAndLong, help: "Output path (.html or .pdf). If omitted, defaults to input filename with the chosen extension (or output.html when using --stdin).")
+	@Option(name: .shortAndLong, help: "Output path (.html, .pdf, .docx, .pages, or .epub). If omitted, defaults to input filename with the chosen extension (or output.html when using --stdin).")
 	var output: String?
 
-	@Option(name: .long, help: "Override output format (html|pdf|docx|pages). If omitted, inferred from output extension; defaults to html.")
+	@Option(name: .long, help: "Override output format (html|pdf|docx|pages|epub). If omitted, inferred from output extension; defaults to html.")
 	var format: RenderOutputFormat?
 
 	@Option(name: .long, help: "Paper size for PDF/HTML print CSS: a4, letter (default: a4).")
@@ -57,6 +63,26 @@ struct Render: AsyncParsableCommand {
 
 	@Option(name: .long, help: "For PDF output, the rendering engine: webkit (macOS only, full CSS) or swift (cross-platform, no WebKit). Defaults to webkit on macOS, swift elsewhere.")
 	var engine: RenderEngine = .platformDefault
+
+	// MARK: EPUB / shared options
+
+	@Option(name: .long, help: "Custom CSS file, applied to HTML, PDF, and EPUB output (appended after the built-in styles so its rules win).")
+	var css: String?
+
+	@Option(name: .long, help: "For EPUB output, a cover image file (JPEG/PNG). Apple Books wants at least 1400px wide.")
+	var cover: String?
+
+	@Option(name: .long, help: "For EPUB output, the book title (dc:title). Defaults to the first top-level heading, or the input filename.")
+	var title: String?
+
+	@Option(name: .long, help: "For EPUB output, an author (dc:creator). Repeat for multiple authors.")
+	var author: [String] = []
+
+	@Option(name: .long, help: "For EPUB output, the BCP-47 language tag (dc:language). Default: en.")
+	var language: String = "en"
+
+	@Option(name: .long, help: "For EPUB output, the heading level (h1–h6) that starts each chapter file. Default: h1.")
+	var chapterLevel: HeadingBreakLevel = .h1
 
 	func run() async throws {
 		#if os(macOS)
@@ -92,14 +118,15 @@ struct Render: AsyncParsableCommand {
 
 		let chosenFormat = try resolvedFormat()
 		let outputURL = try resolvedOutputURL(format: chosenFormat)
+		let userCSS = try loadUserCSS()
 
 		switch chosenFormat {
 		case .html:
-			let html = markdownToHTML(markdownText, paper: paper, landscape: landscape, pageBreakBefore: pageBreakBefore)
+			let html = markdownToHTML(markdownText, paper: paper, landscape: landscape, pageBreakBefore: pageBreakBefore, extraCSS: userCSS)
 			try writeString(html, to: outputURL)
 			print(outputURL.path)
 		case .pdf:
-			let html = markdownToHTML(markdownText, paper: paper, landscape: landscape, pageBreakBefore: pageBreakBefore)
+			let html = markdownToHTML(markdownText, paper: paper, landscape: landscape, pageBreakBefore: pageBreakBefore, extraCSS: userCSS)
 			try await renderPDF(html: html, baseURL: baseURL, outputURL: outputURL)
 			print(outputURL.path)
 		case .docx:
@@ -108,7 +135,69 @@ struct Render: AsyncParsableCommand {
 		case .pages:
 			try MarkdownToPages.convert(markdownText, to: outputURL, packaging: package ? .package : .singleFile, baseURL: baseURL)
 			print(outputURL.path)
+		case .epub:
+			try renderEPUB(markdownText, baseURL: baseURL, outputURL: outputURL, userCSS: userCSS)
+			print(outputURL.path)
 		}
+	}
+
+	// MARK: - EPUB
+
+	private func renderEPUB(_ markdown: String, baseURL: URL?, outputURL: URL, userCSS: String?) throws {
+		var coverData: Data?
+		var coverFilename: String?
+		if let cover {
+			let coverURL = resolvedFileURL(cover)
+			guard FileManager.default.fileExists(atPath: coverURL.path) else {
+				throw ValidationError("Cover image not found: \(coverURL.path)")
+			}
+			coverData = try Data(contentsOf: coverURL)
+			coverFilename = coverURL.lastPathComponent
+		}
+
+		let resolvedTitle = title ?? inferTitle(from: markdown) ?? (input.map { URL(fileURLWithPath: $0).deletingPathExtension().lastPathComponent } ?? "Untitled")
+
+		let metadata = EpubMetadata(
+			title: resolvedTitle,
+			authors: author,
+			language: language,
+			coverImage: coverData,
+			coverImageFilename: coverFilename)
+		let options = EpubOptions(chapterLevel: chapterLevel.numericLevel, userCSS: userCSS)
+		try MarkdownToEpub.convert(markdown, to: outputURL, metadata: metadata, options: options)
+	}
+
+	/// The first ATX heading's text, used as a default EPUB title. Skips fenced
+	/// code blocks so a `# …` line inside ``` fences isn't mistaken for a heading.
+	private func inferTitle(from markdown: String) -> String? {
+		var fence: Character?
+		for rawLine in markdown.split(separator: "\n", omittingEmptySubsequences: false) {
+			let line = rawLine.trimmingCharacters(in: .whitespaces)
+			// Toggle in/out of a fenced code block on ``` or ~~~.
+			if line.hasPrefix("```") || line.hasPrefix("~~~") {
+				let marker = line.first!
+				if fence == nil { fence = marker } else if fence == marker { fence = nil }
+				continue
+			}
+			guard fence == nil, line.hasPrefix("#") else { continue }
+			let hashes = line.prefix { $0 == "#" }
+			guard (1...6).contains(hashes.count) else { continue }
+			let rest = line.dropFirst(hashes.count)
+			guard rest.first == " " else { continue }
+			let text = rest.trimmingCharacters(in: .whitespaces)
+			if !text.isEmpty { return text }
+		}
+		return nil
+	}
+
+	/// Loads the `--css` file if given.
+	private func loadUserCSS() throws -> String? {
+		guard let css else { return nil }
+		let cssURL = resolvedFileURL(css)
+		guard FileManager.default.fileExists(atPath: cssURL.path) else {
+			throw ValidationError("CSS file not found: \(cssURL.path)")
+		}
+		return try String(contentsOf: cssURL, encoding: .utf8)
 	}
 
 	// MARK: - Helpers
@@ -121,7 +210,8 @@ struct Render: AsyncParsableCommand {
 			if ext == "html" || ext == "htm" { return .html }
 			if ext == "docx" { return .docx }
 			if ext == "pages" { return .pages }
-			throw ValidationError("Cannot infer format from output extension '.\(ext)'. Use --format html|pdf|docx|pages.")
+			if ext == "epub" { return .epub }
+			throw ValidationError("Cannot infer format from output extension '.\(ext)'. Use --format html|pdf|docx|pages|epub.")
 		}
 		return .html
 	}
@@ -150,6 +240,7 @@ struct Render: AsyncParsableCommand {
 		case .pdf: return "pdf"
 		case .docx: return "docx"
 		case .pages: return "pages"
+		case .epub: return "epub"
 		}
 	}
 

--- a/Sources/SwiftTextEPUB/ChapterSplitter.swift
+++ b/Sources/SwiftTextEPUB/ChapterSplitter.swift
@@ -1,0 +1,83 @@
+//  ChapterSplitter.swift
+//  SwiftTextEPUB
+//
+//  Splits a parsed Markdown document into per-chapter XHTML fragments. A new
+//  chapter file begins at every heading of the chosen level; any content before
+//  the first such heading becomes a single front-matter section. Each chapter's
+//  body is rendered through the Markdown renderer's XHTML mode so it is
+//  well-formed XML suitable for an EPUB content document.
+
+import Foundation
+import Markdown
+import SwiftTextMarkdown
+
+/// One rendered chapter (or the front-matter section) of an EPUB.
+struct EpubChapter {
+	/// Stable id/basename, e.g. `ch001` — used for the file, manifest item, and
+	/// the section anchor the nav/NCX point at.
+	let id: String
+	/// The heading text shown in the table of contents.
+	let title: String
+	/// The rendered XHTML body fragment (already escaped, void elements closed).
+	let bodyXHTML: String
+	/// Front matter is emitted in the spine but kept out of the reading-order
+	/// table of contents (it has no chapter heading of its own).
+	let isFrontmatter: Bool
+}
+
+enum ChapterSplitter {
+
+	/// Splits `document` into chapters at headings of exactly `chapterLevel`
+	/// (1–6). Leading content becomes front matter. `titleFallback` names a
+	/// chapter whose heading is empty (or the front matter, which is never
+	/// listed but still needs an id).
+	static func split(document: Document, chapterLevel: Int, titleFallback: String) -> [EpubChapter] {
+		let level = max(1, min(chapterLevel, 6))
+		let blocks = document.children.compactMap { $0 as? BlockMarkup }
+
+		// Partition top-level blocks into runs, each starting at a split heading.
+		var runs: [(heading: Heading?, blocks: [BlockMarkup])] = []
+		for block in blocks {
+			if let heading = block as? Heading, heading.level == level {
+				runs.append((heading, [block]))
+			} else if runs.isEmpty {
+				// Before the first split heading: begin the front-matter run.
+				runs.append((nil, [block]))
+			} else {
+				runs[runs.count - 1].blocks.append(block)
+			}
+		}
+
+		var chapters: [EpubChapter] = []
+		var chapterNumber = 0
+		for run in runs {
+			let isFrontmatter = run.heading == nil
+			chapterNumber += 1
+			let id = String(format: "ch%03d", chapterNumber)
+			let body = renderBody(run.blocks)
+			let title = chapterTitle(from: run.blocks, fallback: titleFallback)
+			chapters.append(EpubChapter(id: id, title: title, bodyXHTML: body, isFrontmatter: isFrontmatter))
+		}
+		return chapters
+	}
+
+	/// A chapter's title is its run of leading consecutive headings, joined with
+	/// ": " — so a `## 1` immediately followed by `### The Birthday…` reads as
+	/// "1: The Birthday…" in the table of contents while both headings still
+	/// appear in the chapter body. Falls back to `fallback` when there is no
+	/// leading heading (e.g. the front-matter section).
+	private static func chapterTitle(from blocks: [BlockMarkup], fallback: String) -> String {
+		let leadingHeadings = blocks.prefix { $0 is Heading }.compactMap { $0 as? Heading }
+		let parts = leadingHeadings
+			.map { swiftMarkdownPlainText(of: $0).trimmingCharacters(in: .whitespacesAndNewlines) }
+			.filter { !$0.isEmpty }
+		let title = parts.joined(separator: ": ")
+		return title.isEmpty ? fallback : title
+	}
+
+	/// Renders a run of top-level blocks to an XHTML fragment.
+	private static func renderBody(_ blocks: [BlockMarkup]) -> String {
+		let subdocument = Document(blocks, inheritSourceRange: false)
+		return SwiftMarkdownHTMLRenderer.convert(document: subdocument, options: [.xhtml])
+	}
+}

--- a/Sources/SwiftTextEPUB/CoverImage.swift
+++ b/Sources/SwiftTextEPUB/CoverImage.swift
@@ -1,0 +1,71 @@
+//  CoverImage.swift
+//  SwiftTextEPUB
+//
+//  Sniffs a cover image's format from its bytes so the OPF manifest can declare
+//  the right media-type and the cover page can size its SVG wrapper to the
+//  image's pixel dimensions (the technique Apple Books and other reading systems
+//  want for a full-bleed cover).
+
+import Foundation
+import SwiftTextCore
+
+/// A resolved cover image ready to embed: its bytes, in-package path, declared
+/// media-type, and pixel dimensions when they can be read from the header.
+struct CoverImage {
+	let data: Data
+	/// Path inside the container, e.g. `images/cover.jpg`.
+	let path: String
+	let mediaType: String
+	let width: Int?
+	let height: Int?
+
+	/// Resolves a cover from raw bytes, sniffing the format (falling back to the
+	/// original filename's extension, then JPEG). Returns `nil` for empty data.
+	init?(data: Data, originalFilename: String?) {
+		guard !data.isEmpty else { return nil }
+		self.data = data
+
+		let bytes = [UInt8](data.prefix(16))
+		let (mediaType, ext) = Self.format(bytes: bytes, filename: originalFilename)
+		self.mediaType = mediaType
+		self.path = "images/cover.\(ext)"
+
+		if let size = ImageDimensions.dimensions(of: [UInt8](data)) {
+			self.width = size.width
+			self.height = size.height
+		} else {
+			self.width = nil
+			self.height = nil
+		}
+	}
+
+	/// Maps magic bytes (then a filename extension) to an EPUB core media-type.
+	private static func format(bytes: [UInt8], filename: String?) -> (mediaType: String, ext: String) {
+		if bytes.count >= 3, bytes[0] == 0xFF, bytes[1] == 0xD8, bytes[2] == 0xFF {
+			return ("image/jpeg", "jpg")
+		}
+		if bytes.count >= 8, bytes[0] == 0x89, bytes[1] == 0x50, bytes[2] == 0x4E, bytes[3] == 0x47 {
+			return ("image/png", "png")
+		}
+		if bytes.count >= 6, bytes[0] == 0x47, bytes[1] == 0x49, bytes[2] == 0x46 { // "GIF"
+			return ("image/gif", "gif")
+		}
+		if bytes.count >= 12, bytes[0] == 0x52, bytes[1] == 0x49, bytes[2] == 0x46, bytes[3] == 0x46, // RIFF
+		   bytes[8] == 0x57, bytes[9] == 0x45, bytes[10] == 0x42, bytes[11] == 0x50 {                  // WEBP
+			return ("image/webp", "webp")
+		}
+		// SVG is text; look for a leading '<' after any BOM/whitespace.
+		if let first = bytes.first(where: { $0 != 0x20 && $0 != 0x09 && $0 != 0x0A && $0 != 0x0D && $0 != 0xEF && $0 != 0xBB && $0 != 0xBF }),
+		   first == 0x3C {
+			return ("image/svg+xml", "svg")
+		}
+
+		switch (filename as NSString?)?.pathExtension.lowercased() {
+		case "png": return ("image/png", "png")
+		case "gif": return ("image/gif", "gif")
+		case "webp": return ("image/webp", "webp")
+		case "svg": return ("image/svg+xml", "svg")
+		default: return ("image/jpeg", "jpg")
+		}
+	}
+}

--- a/Sources/SwiftTextEPUB/DefaultStylesheet.swift
+++ b/Sources/SwiftTextEPUB/DefaultStylesheet.swift
@@ -1,0 +1,113 @@
+//  DefaultStylesheet.swift
+//  SwiftTextEPUB
+//
+//  The bundled reading stylesheet, referenced by every content document. Tuned
+//  for long-form prose: a serif face, first-line-indented paragraphs with no
+//  inter-paragraph gap (the print-book convention), a centered scene-break rule,
+//  each chapter starting on a new page, and a centered title page. User CSS
+//  passed to the converter is appended after this so author rules win.
+
+enum DefaultStylesheet {
+	static let css = """
+	/* SwiftText EPUB base stylesheet */
+	html {
+	  font-family: Georgia, "Times New Roman", serif;
+	  line-height: 1.5;
+	  color: #1a1a1a;
+	}
+	body {
+	  margin: 0 5%;
+	  widows: 2;
+	  orphans: 2;
+	}
+	h1, h2, h3, h4, h5, h6 {
+	  font-weight: bold;
+	  line-height: 1.2;
+	  text-align: left;
+	  page-break-after: avoid;
+	  break-after: avoid;
+	  page-break-inside: avoid;
+	}
+	h1 {
+	  font-size: 1.8em;
+	  margin: 1em 0 0.8em;
+	  page-break-before: always;
+	  break-before: page;
+	}
+	h2 { font-size: 1.4em; margin: 1.2em 0 0.6em; }
+	h3 { font-size: 1.15em; margin: 1em 0 0.4em; }
+	h4, h5, h6 { font-size: 1em; margin: 1em 0 0.3em; }
+	p {
+	  margin: 0;
+	  text-indent: 1.2em;
+	  text-align: justify;
+	}
+	/* The opening paragraph of a section or after a scene break is not indented. */
+	h1 + p, h2 + p, h3 + p, h4 + p, h5 + p, h6 + p, hr + p, blockquote > p:first-child {
+	  text-indent: 0;
+	}
+	blockquote {
+	  margin: 1em 1.5em;
+	  font-style: italic;
+	}
+	blockquote p { text-align: left; }
+	hr {
+	  border: none;
+	  width: 25%;
+	  margin: 1.5em auto;
+	  border-top: 1px solid currentColor;
+	}
+	em { font-style: italic; }
+	strong { font-weight: bold; }
+	del { text-decoration: line-through; }
+	a { color: inherit; text-decoration: underline; }
+	code {
+	  font-family: "SFMono-Regular", Menlo, Consolas, monospace;
+	  font-size: 0.9em;
+	}
+	pre {
+	  margin: 1em 0;
+	  white-space: pre-wrap;
+	  overflow-wrap: break-word;
+	  font-size: 0.9em;
+	}
+	pre code { font-size: inherit; }
+	ul, ol { margin: 1em 0 1em 1.5em; padding: 0; }
+	li { margin: 0.2em 0; }
+	li.task-list-item { list-style: none; margin-left: -1.2em; }
+	table { border-collapse: collapse; margin: 1em 0; }
+	th, td { border: 1px solid #888; padding: 0.3em 0.6em; text-align: left; }
+	th { font-weight: bold; }
+	img { max-width: 100%; height: auto; }
+	sup { vertical-align: super; font-size: smaller; }
+	sub { vertical-align: sub; font-size: smaller; }
+
+	/* Title page */
+	section.titlepage {
+	  text-align: center;
+	  margin-top: 20%;
+	}
+	h1.title {
+	  font-size: 2.4em;
+	  margin: 0 0 0.6em;
+	  page-break-before: avoid;
+	  break-before: avoid;
+	}
+	p.author {
+	  font-size: 1.3em;
+	  text-indent: 0;
+	  text-align: center;
+	  margin: 0.3em 0;
+	}
+
+	/* Cover */
+	body.cover, section.cover { margin: 0; padding: 0; text-align: center; }
+	#cover-image { margin: 0; padding: 0; }
+	#cover-image img { max-width: 100%; max-height: 100%; }
+
+	/* Navigation document */
+	nav#toc ol { list-style-type: none; padding: 0; margin: 0 0 0 1em; }
+	nav#toc ol li { margin: 0.4em 0; }
+	nav#toc a { text-decoration: none; }
+	"""
+}

--- a/Sources/SwiftTextEPUB/EpubArchiveWriter.swift
+++ b/Sources/SwiftTextEPUB/EpubArchiveWriter.swift
@@ -1,0 +1,64 @@
+//  EpubArchiveWriter.swift
+//  SwiftTextEPUB
+//
+//  Packages the built EPUB files into the OCF ZIP container. The one hard rule
+//  the format adds over an ordinary zip: the `mimetype` entry must come first
+//  and be stored (uncompressed) with no extra field, so a reading system can
+//  sniff the media type from a fixed offset before parsing anything. Everything
+//  else is deflated, except already-compressed cover images, which are stored.
+
+import Foundation
+import ZIPFoundation
+
+/// How a single packaged file is stored in the container.
+enum EpubCompression {
+	case stored
+	case deflate
+}
+
+/// One file destined for the EPUB container, with its in-archive path.
+struct EpubFile {
+	let path: String
+	let data: Data
+	let compression: EpubCompression
+}
+
+enum EpubArchiveWriter {
+
+	/// Writes `files` to a new EPUB archive at `url`, in the given order. The
+	/// caller is responsible for placing `mimetype` first with `.stored`
+	/// compression. `modificationDate` stamps every entry so the same input
+	/// yields byte-identical output.
+	static func write(_ files: [EpubFile], to url: URL, modificationDate: Date) throws {
+		let directory = url.deletingLastPathComponent()
+		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+		if FileManager.default.fileExists(atPath: url.path) {
+			try FileManager.default.removeItem(at: url)
+		}
+
+		let archive = try Archive(url: url, accessMode: .create)
+		for file in files {
+			let method: CompressionMethod = file.compression == .stored ? .none : .deflate
+			let data = file.data
+			try archive.addEntry(
+				with: file.path,
+				type: .file,
+				uncompressedSize: Int64(data.count),
+				modificationDate: modificationDate,
+				compressionMethod: method
+			) { position, size in
+				data.subdata(in: Data.Index(position) ..< Data.Index(position) + size)
+			}
+		}
+	}
+
+	/// Builds the archive in a temporary file and returns its bytes. Useful for
+	/// callers (and tests) that want the EPUB as `Data` rather than on disk.
+	static func makeData(_ files: [EpubFile], modificationDate: Date) throws -> Data {
+		let temporary = FileManager.default.temporaryDirectory
+			.appendingPathComponent("swifttext-epub-\(UUID().uuidString).epub")
+		defer { try? FileManager.default.removeItem(at: temporary) }
+		try write(files, to: temporary, modificationDate: modificationDate)
+		return try Data(contentsOf: temporary)
+	}
+}

--- a/Sources/SwiftTextEPUB/EpubMetadata.swift
+++ b/Sources/SwiftTextEPUB/EpubMetadata.swift
@@ -1,0 +1,59 @@
+//  EpubMetadata.swift
+//  SwiftTextEPUB
+//
+//  The Dublin Core / EPUB package metadata that drives the OPF and nav
+//  documents: title, author(s), language, a unique identifier, the last-modified
+//  timestamp, and an optional cover image.
+
+import Foundation
+
+/// Metadata for an EPUB publication.
+///
+/// Mirrors the subset of Dublin Core / EPUB `<metadata>` a single-author book
+/// needs. `identifier` and `modified` default to a fresh random UUID and the
+/// current time; pass explicit values for a reproducible build (e.g. in tests).
+public struct EpubMetadata: Sendable {
+	/// The book title (`dc:title`).
+	public var title: String
+	/// The author(s), in reading order (`dc:creator`, role `aut`).
+	public var authors: [String]
+	/// BCP-47 language tag (`dc:language`), e.g. `"en"`.
+	public var language: String
+	/// The publication's unique identifier (`dc:identifier`). A `urn:uuid:…`
+	/// string by default; any stable, globally unique URN/URI is valid.
+	public var identifier: String
+	/// The last-modified instant (`dcterms:modified`), serialized as UTC.
+	public var modified: Date
+	/// The raw bytes of the cover image, if any.
+	public var coverImage: Data?
+	/// The cover image's original filename, used only to pick an extension when
+	/// the format can't be sniffed from the bytes. Optional.
+	public var coverImageFilename: String?
+
+	public init(
+		title: String,
+		authors: [String] = [],
+		language: String = "en",
+		identifier: String? = nil,
+		modified: Date? = nil,
+		coverImage: Data? = nil,
+		coverImageFilename: String? = nil
+	) {
+		self.title = title
+		self.authors = authors
+		self.language = language.isEmpty ? "en" : language
+		self.identifier = identifier ?? "urn:uuid:\(UUID().uuidString.lowercased())"
+		self.modified = modified ?? Date()
+		self.coverImage = coverImage
+		self.coverImageFilename = coverImageFilename
+	}
+
+	/// `dcterms:modified` requires a UTC timestamp with no fractional seconds
+	/// (`CCYY-MM-DDThh:mm:ssZ`), per the EPUB spec.
+	var modifiedUTCString: String {
+		let formatter = ISO8601DateFormatter()
+		formatter.timeZone = TimeZone(identifier: "UTC")
+		formatter.formatOptions = [.withInternetDateTime]
+		return formatter.string(from: modified)
+	}
+}

--- a/Sources/SwiftTextEPUB/EpubPackage.swift
+++ b/Sources/SwiftTextEPUB/EpubPackage.swift
@@ -1,0 +1,288 @@
+//  EpubPackage.swift
+//  SwiftTextEPUB
+//
+//  Assembles every file in the EPUB: the OCF `container.xml`, the OPF package
+//  document (Dublin Core metadata + manifest + spine), the EPUB3 nav document
+//  and legacy NCX, the optional cover and generated title page, and one XHTML
+//  content document per chapter. Emits an ordered `[EpubFile]` for the archive
+//  writer, with `mimetype` first and stored.
+
+import Foundation
+
+enum EpubPackageBuilder {
+
+	/// The container directory holding the OPF and content — `OEBPS` by convention.
+	private static let contentDirectory = "OEBPS"
+
+	/// Builds the ordered file list for an EPUB from its parts.
+	static func build(metadata: EpubMetadata, chapters: [EpubChapter], cover: CoverImage?, userCSS: String?) -> [EpubFile] {
+		var files: [EpubFile] = []
+
+		// 1. mimetype — MUST be first and stored, per the OCF spec.
+		files.append(EpubFile(path: "mimetype", data: Data("application/epub+zip".utf8), compression: .stored))
+
+		// 2. OCF container pointing at the package document.
+		files.append(text("META-INF/container.xml", containerXML()))
+
+		// 3. Stylesheet (bundled default + optional appended user CSS).
+		var css = DefaultStylesheet.css
+		if let userCSS, !userCSS.isEmpty {
+			css += "\n\n/* User stylesheet */\n" + userCSS
+		}
+		files.append(text("\(contentDirectory)/styles/stylesheet.css", css))
+
+		// 4. Cover image + cover page.
+		if let cover {
+			files.append(EpubFile(path: "\(contentDirectory)/\(cover.path)", data: cover.data, compression: .stored))
+			files.append(text("\(contentDirectory)/text/cover.xhtml", coverXHTML(cover: cover, language: metadata.language)))
+		}
+
+		// 5. Generated title page.
+		files.append(text("\(contentDirectory)/text/titlepage.xhtml", titlePageXHTML(metadata: metadata)))
+
+		// 6. Chapter content documents.
+		for chapter in chapters {
+			files.append(text("\(contentDirectory)/text/\(chapter.id).xhtml", chapterXHTML(chapter: chapter, language: metadata.language)))
+		}
+
+		// 7. Navigation documents.
+		files.append(text("\(contentDirectory)/nav.xhtml", navXHTML(metadata: metadata, chapters: chapters, hasCover: cover != nil)))
+		files.append(text("\(contentDirectory)/toc.ncx", ncx(metadata: metadata, chapters: chapters)))
+
+		// 8. The package document last (its content depends on all the above).
+		files.append(text("\(contentDirectory)/content.opf", opf(metadata: metadata, chapters: chapters, cover: cover)))
+
+		return files
+	}
+
+	// MARK: - File helpers
+
+	private static func text(_ path: String, _ content: String) -> EpubFile {
+		EpubFile(path: path, data: Data(content.utf8), compression: .deflate)
+	}
+
+	/// Wraps a body fragment in a complete XHTML document.
+	private static func xhtmlDocument(title: String, cssHref: String, bodyType: String?, bodyClass: String?, body: String, language: String) -> String {
+		let lang = XML.escapeAttribute(language)
+		let bodyAttrs = [
+			bodyType.map { "epub:type=\"\($0)\"" },
+			bodyClass.map { "class=\"\($0)\"" }
+		].compactMap { $0 }.joined(separator: " ")
+		let bodyTag = bodyAttrs.isEmpty ? "<body>" : "<body \(bodyAttrs)>"
+		return """
+		<?xml version="1.0" encoding="UTF-8"?>
+		<!DOCTYPE html>
+		<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" lang="\(lang)" xml:lang="\(lang)">
+		<head>
+		<meta charset="utf-8"/>
+		<title>\(XML.escapeText(title))</title>
+		<link rel="stylesheet" type="text/css" href="\(cssHref)"/>
+		</head>
+		\(bodyTag)
+		\(body)
+		</body>
+		</html>
+		"""
+	}
+
+	// MARK: - Container
+
+	private static func containerXML() -> String {
+		"""
+		<?xml version="1.0" encoding="UTF-8"?>
+		<container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+		  <rootfiles>
+		    <rootfile full-path="\(contentDirectory)/content.opf" media-type="application/oebps-package+xml"/>
+		  </rootfiles>
+		</container>
+		"""
+	}
+
+	// MARK: - Content documents
+
+	private static func chapterXHTML(chapter: EpubChapter, language: String) -> String {
+		let bodyType = chapter.isFrontmatter ? "frontmatter" : "bodymatter"
+		let sectionType = chapter.isFrontmatter ? "frontmatter" : "chapter"
+		let section = """
+		<section id="\(chapter.id)" epub:type="\(sectionType)">
+		\(chapter.bodyXHTML)
+		</section>
+		"""
+		return xhtmlDocument(
+			title: chapter.title,
+			cssHref: "../styles/stylesheet.css",
+			bodyType: bodyType,
+			bodyClass: nil,
+			body: section,
+			language: language
+		)
+	}
+
+	private static func titlePageXHTML(metadata: EpubMetadata) -> String {
+		var body = "<section epub:type=\"titlepage\" class=\"titlepage\">\n"
+		body += "<h1 class=\"title\">\(XML.escapeText(metadata.title))</h1>\n"
+		for author in metadata.authors where !author.isEmpty {
+			body += "<p class=\"author\">\(XML.escapeText(author))</p>\n"
+		}
+		body += "</section>"
+		return xhtmlDocument(
+			title: metadata.title,
+			cssHref: "../styles/stylesheet.css",
+			bodyType: "frontmatter",
+			bodyClass: nil,
+			body: body,
+			language: metadata.language
+		)
+	}
+
+	private static func coverXHTML(cover: CoverImage, language: String) -> String {
+		let href = "../\(cover.path)"
+		let inner: String
+		if let width = cover.width, let height = cover.height, width > 0, height > 0 {
+			// An SVG wrapper scaled to the image lets the cover fill the screen
+			// while preserving aspect ratio — the technique reading systems expect.
+			inner = """
+			<div id="cover-image">
+			<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="100%" height="100%" viewBox="0 0 \(width) \(height)" preserveAspectRatio="xMidYMid meet">
+			<image width="\(width)" height="\(height)" xlink:href="\(XML.escapeAttribute(href))"/>
+			</svg>
+			</div>
+			"""
+		} else {
+			inner = "<div id=\"cover-image\"><img src=\"\(XML.escapeAttribute(href))\" alt=\"Cover\"/></div>"
+		}
+		return xhtmlDocument(
+			title: "Cover",
+			cssHref: "../styles/stylesheet.css",
+			bodyType: "cover",
+			bodyClass: "cover",
+			body: inner,
+			language: language
+		)
+	}
+
+	// MARK: - Navigation
+
+	private static func navXHTML(metadata: EpubMetadata, chapters: [EpubChapter], hasCover: Bool) -> String {
+		let tocItems = chapters.filter { !$0.isFrontmatter }.map { chapter in
+			"      <li><a href=\"text/\(chapter.id).xhtml#\(chapter.id)\">\(XML.escapeText(chapter.title))</a></li>"
+		}.joined(separator: "\n")
+
+		var landmarks = ""
+		if hasCover {
+			landmarks += "      <li><a href=\"text/cover.xhtml\" epub:type=\"cover\">Cover</a></li>\n"
+		}
+		landmarks += "      <li><a href=\"text/titlepage.xhtml\" epub:type=\"titlepage\">Title Page</a></li>\n"
+		landmarks += "      <li><a href=\"nav.xhtml#toc\" epub:type=\"toc\">Table of Contents</a></li>"
+		if let firstBody = chapters.first(where: { !$0.isFrontmatter }) {
+			landmarks += "\n      <li><a href=\"text/\(firstBody.id).xhtml\" epub:type=\"bodymatter\">Beginning</a></li>"
+		}
+
+		let body = """
+		<nav epub:type="toc" id="toc" role="doc-toc">
+		<h1>\(XML.escapeText(metadata.title))</h1>
+		    <ol>
+		\(tocItems)
+		    </ol>
+		</nav>
+		<nav epub:type="landmarks" id="landmarks" hidden="hidden">
+		    <ol>
+		\(landmarks)
+		    </ol>
+		</nav>
+		"""
+		return xhtmlDocument(
+			title: "Table of Contents",
+			cssHref: "styles/stylesheet.css",
+			bodyType: "frontmatter",
+			bodyClass: nil,
+			body: body,
+			language: metadata.language
+		)
+	}
+
+	private static func ncx(metadata: EpubMetadata, chapters: [EpubChapter]) -> String {
+		var navPoints = ""
+		var order = 0
+		for chapter in chapters where !chapter.isFrontmatter {
+			order += 1
+			navPoints += """
+			    <navPoint id="navPoint-\(order)" playOrder="\(order)">
+			      <navLabel><text>\(XML.escapeText(chapter.title))</text></navLabel>
+			      <content src="text/\(chapter.id).xhtml#\(chapter.id)"/>
+			    </navPoint>
+
+			"""
+		}
+		return """
+		<?xml version="1.0" encoding="UTF-8"?>
+		<ncx version="2005-1" xmlns="http://www.daisy.org/z3986/2005/ncx/">
+		  <head>
+		    <meta name="dtb:uid" content="\(XML.escapeAttribute(metadata.identifier))"/>
+		    <meta name="dtb:depth" content="1"/>
+		    <meta name="dtb:totalPageCount" content="0"/>
+		    <meta name="dtb:maxPageNumber" content="0"/>
+		  </head>
+		  <docTitle><text>\(XML.escapeText(metadata.title))</text></docTitle>
+		  <navMap>
+		\(navPoints)  </navMap>
+		</ncx>
+		"""
+	}
+
+	// MARK: - Package document (OPF)
+
+	private static func opf(metadata: EpubMetadata, chapters: [EpubChapter], cover: CoverImage?) -> String {
+		// Metadata
+		var meta = "    <dc:identifier id=\"pub-id\">\(XML.escapeText(metadata.identifier))</dc:identifier>\n"
+		meta += "    <dc:title>\(XML.escapeText(metadata.title))</dc:title>\n"
+		meta += "    <dc:language>\(XML.escapeText(metadata.language))</dc:language>\n"
+		for (index, author) in metadata.authors.enumerated() where !author.isEmpty {
+			let id = "creator-\(index + 1)"
+			meta += "    <dc:creator id=\"\(id)\">\(XML.escapeText(author))</dc:creator>\n"
+			meta += "    <meta refines=\"#\(id)\" property=\"role\" scheme=\"marc:relators\">aut</meta>\n"
+		}
+		meta += "    <meta property=\"dcterms:modified\">\(metadata.modifiedUTCString)</meta>"
+		if cover != nil {
+			meta += "\n    <meta name=\"cover\" content=\"cover-image\"/>"
+		}
+
+		// Manifest
+		var manifest = "    <item id=\"nav\" href=\"nav.xhtml\" media-type=\"application/xhtml+xml\" properties=\"nav\"/>\n"
+		manifest += "    <item id=\"ncx\" href=\"toc.ncx\" media-type=\"application/x-dtbncx+xml\"/>\n"
+		manifest += "    <item id=\"css\" href=\"styles/stylesheet.css\" media-type=\"text/css\"/>\n"
+		if let cover {
+			manifest += "    <item id=\"cover-image\" href=\"\(cover.path)\" media-type=\"\(cover.mediaType)\" properties=\"cover-image\"/>\n"
+			let svgProperty = (cover.width != nil && cover.height != nil) ? " properties=\"svg\"" : ""
+			manifest += "    <item id=\"cover\" href=\"text/cover.xhtml\" media-type=\"application/xhtml+xml\"\(svgProperty)/>\n"
+		}
+		manifest += "    <item id=\"titlepage\" href=\"text/titlepage.xhtml\" media-type=\"application/xhtml+xml\"/>\n"
+		for chapter in chapters {
+			manifest += "    <item id=\"\(chapter.id)\" href=\"text/\(chapter.id).xhtml\" media-type=\"application/xhtml+xml\"/>\n"
+		}
+
+		// Spine: cover, title page, nav, then chapters in document order.
+		var spine = ""
+		if cover != nil {
+			spine += "    <itemref idref=\"cover\" linear=\"no\"/>\n"
+		}
+		spine += "    <itemref idref=\"titlepage\"/>\n"
+		spine += "    <itemref idref=\"nav\"/>\n"
+		for chapter in chapters {
+			spine += "    <itemref idref=\"\(chapter.id)\"/>\n"
+		}
+
+		return """
+		<?xml version="1.0" encoding="UTF-8"?>
+		<package xmlns="http://www.idpf.org/2007/opf" version="3.0" xml:lang="\(XML.escapeAttribute(metadata.language))" unique-identifier="pub-id">
+		  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+		\(meta)
+		  </metadata>
+		  <manifest>
+		\(manifest)  </manifest>
+		  <spine toc="ncx">
+		\(spine)  </spine>
+		</package>
+		"""
+	}
+}

--- a/Sources/SwiftTextEPUB/MarkdownToEpub.swift
+++ b/Sources/SwiftTextEPUB/MarkdownToEpub.swift
@@ -1,0 +1,74 @@
+//  MarkdownToEpub.swift
+//  SwiftTextEPUB
+//
+//  The public entry point: turn a Markdown manuscript (plus metadata and an
+//  optional cover) into an EPUB 3 file. Chapters are split at a configurable
+//  heading level and each becomes its own XHTML content document, wired into the
+//  OPF manifest/spine and the nav/NCX tables of contents.
+
+import Foundation
+import Markdown
+
+/// Options controlling EPUB generation.
+public struct EpubOptions: Sendable {
+	/// Heading level (1–6) at which a new chapter file begins. Content before the
+	/// first heading of this level becomes a front-matter section. Default: 1.
+	public var chapterLevel: Int
+	/// CSS appended after the bundled stylesheet (so its rules win), shared by
+	/// every content document. `nil` uses only the default stylesheet.
+	public var userCSS: String?
+
+	public init(chapterLevel: Int = 1, userCSS: String? = nil) {
+		self.chapterLevel = chapterLevel
+		self.userCSS = userCSS
+	}
+}
+
+/// Converts Markdown text to an EPUB 3 publication.
+///
+/// Usage:
+/// ```swift
+/// let metadata = EpubMetadata(title: "The Shattered Skies", authors: ["Elise Kummer"])
+/// try MarkdownToEpub.convert(markdown, to: outputURL, metadata: metadata,
+///                            options: EpubOptions(chapterLevel: 2))
+/// ```
+public enum MarkdownToEpub {
+
+	/// Writes an EPUB for `markdown` to `url`.
+	public static func convert(_ markdown: String, to url: URL, metadata: EpubMetadata, options: EpubOptions = EpubOptions()) throws {
+		let files = makeFiles(markdown, metadata: metadata, options: options)
+		try EpubArchiveWriter.write(files, to: url, modificationDate: metadata.modified)
+	}
+
+	/// Builds an EPUB for `markdown` and returns its bytes.
+	public static func makeData(_ markdown: String, metadata: EpubMetadata, options: EpubOptions = EpubOptions()) throws -> Data {
+		let files = makeFiles(markdown, metadata: metadata, options: options)
+		return try EpubArchiveWriter.makeData(files, modificationDate: metadata.modified)
+	}
+
+	/// Builds the ordered container file list (pre-zip). Exposed internally so
+	/// tests can assert on individual documents without unzipping.
+	static func makeFiles(_ markdown: String, metadata: EpubMetadata, options: EpubOptions) -> [EpubFile] {
+		// Parse with smart typography disabled to match the HTML renderer: the
+		// source already carries real typographic characters, so re-substituting
+		// would double-transform them.
+		let document = Document(parsing: markdown, options: [.disableSmartOpts])
+		var chapters = ChapterSplitter.split(document: document, chapterLevel: options.chapterLevel, titleFallback: metadata.title)
+
+		// A table of contents needs at least one entry. If the manuscript has no
+		// heading at the split level, present its whole content as a single
+		// titled chapter (an empty document still yields a one-chapter shell).
+		if !chapters.contains(where: { !$0.isFrontmatter }) {
+			if chapters.isEmpty {
+				chapters = [EpubChapter(id: "ch001", title: metadata.title, bodyXHTML: "", isFrontmatter: false)]
+			} else {
+				chapters = chapters.map {
+					EpubChapter(id: $0.id, title: metadata.title, bodyXHTML: $0.bodyXHTML, isFrontmatter: false)
+				}
+			}
+		}
+
+		let cover = metadata.coverImage.flatMap { CoverImage(data: $0, originalFilename: metadata.coverImageFilename) }
+		return EpubPackageBuilder.build(metadata: metadata, chapters: chapters, cover: cover, userCSS: options.userCSS)
+	}
+}

--- a/Sources/SwiftTextEPUB/XMLEscaping.swift
+++ b/Sources/SwiftTextEPUB/XMLEscaping.swift
@@ -1,0 +1,42 @@
+//  XMLEscaping.swift
+//  SwiftTextEPUB
+//
+//  Escaping for the XML the package builder emits by string interpolation
+//  (OPF, nav, NCX, container, XHTML wrappers). Chapter *bodies* come pre-escaped
+//  from the Markdown renderer's XHTML mode; these helpers cover the metadata and
+//  attribute values the builder injects around them.
+
+import Foundation
+
+enum XML {
+	/// Escapes text content: `&`, `<`, `>`.
+	static func escapeText(_ string: String) -> String {
+		var result = ""
+		result.reserveCapacity(string.count)
+		for character in string {
+			switch character {
+			case "&": result += "&amp;"
+			case "<": result += "&lt;"
+			case ">": result += "&gt;"
+			default: result.append(character)
+			}
+		}
+		return result
+	}
+
+	/// Escapes an attribute value: text plus `"`.
+	static func escapeAttribute(_ string: String) -> String {
+		var result = ""
+		result.reserveCapacity(string.count)
+		for character in string {
+			switch character {
+			case "&": result += "&amp;"
+			case "<": result += "&lt;"
+			case ">": result += "&gt;"
+			case "\"": result += "&quot;"
+			default: result.append(character)
+			}
+		}
+		return result
+	}
+}

--- a/Sources/SwiftTextMarkdown/SwiftMarkdownHTMLRenderer.swift
+++ b/Sources/SwiftTextMarkdown/SwiftMarkdownHTMLRenderer.swift
@@ -38,6 +38,13 @@ public enum SwiftMarkdownHTMLRenderer {
 		/// `<details>`. cmark calls this mode "unsafe": only use it when the
 		/// output is sanitized or displayed without script execution.
 		public static let passThroughRawHTML = Options(rawValue: 1 << 0)
+
+		/// Emits XHTML-serializable markup: void elements are self-closed
+		/// (`<hr />`, `<br />`, `<img … />`) and boolean attributes take their
+		/// XHTML form (`disabled="disabled"`). Use this when the fragment must be
+		/// well-formed XML — e.g. EPUB content documents, which reading systems
+		/// parse as XHTML rather than lenient HTML5.
+		public static let xhtml = Options(rawValue: 1 << 1)
 	}
 
 	public static func convert(_ markdown: String, options: Options = []) -> String {
@@ -66,6 +73,9 @@ private struct HTMLRenderer: MarkupVisitor {
 
 	private var output: String = ""
 	private var alignmentStack: [[Table.ColumnAlignment?]] = []
+
+	/// The close for a void element: `" />"` in XHTML mode, `">"` otherwise.
+	private var voidClose: String { options.contains(.xhtml) ? " />" : ">" }
 
 	mutating func flush() -> String {
 		while output.hasSuffix("\n") { output.removeLast() }
@@ -164,7 +174,7 @@ private struct HTMLRenderer: MarkupVisitor {
 		// (e.g. `![*diagram*](img.png)` or `![link [label]](...)`) is
 		// preserved rather than silently dropped.
 		let alt = swiftMarkdownPlainText(of: image)
-		output += "<img src=\"\(escapeAttribute(src))\" alt=\"\(escapeAttribute(alt))\">"
+		output += "<img src=\"\(escapeAttribute(src))\" alt=\"\(escapeAttribute(alt))\"\(voidClose)"
 	}
 
 	mutating func visitCodeBlock(_ codeBlock: CodeBlock) {
@@ -174,14 +184,14 @@ private struct HTMLRenderer: MarkupVisitor {
 		// simpler escape policy. Smart-punct is also irrelevant inside code.
 		let escaped = escapeHTMLNotQuote(code)
 		if let language = codeBlock.language, !language.isEmpty {
-			output += "<pre><code class=\"language-\(language)\">\(escaped)</code></pre>"
+			output += "<pre><code class=\"language-\(escapeAttribute(language))\">\(escaped)</code></pre>"
 		} else {
 			output += "<pre><code>\(escaped)</code></pre>"
 		}
 	}
 
 	mutating func visitThematicBreak(_ thematicBreak: ThematicBreak) {
-		output += "<hr>"
+		output += "<hr\(voidClose)"
 	}
 
 	mutating func visitUnorderedList(_ unorderedList: UnorderedList) {
@@ -199,9 +209,15 @@ private struct HTMLRenderer: MarkupVisitor {
 	mutating func visitListItem(_ listItem: ListItem) {
 		switch listItem.checkbox {
 		case .checked:
-			output += #"<li class="task-list-item"><input type="checkbox" disabled checked> "#
+			let input = options.contains(.xhtml)
+				? #"<input type="checkbox" disabled="disabled" checked="checked" />"#
+				: #"<input type="checkbox" disabled checked>"#
+			output += #"<li class="task-list-item">"# + input + " "
 		case .unchecked:
-			output += #"<li class="task-list-item"><input type="checkbox" disabled> "#
+			let input = options.contains(.xhtml)
+				? #"<input type="checkbox" disabled="disabled" />"#
+				: #"<input type="checkbox" disabled>"#
+			output += #"<li class="task-list-item">"# + input + " "
 		case .none:
 			output += "<li>"
 		}
@@ -231,7 +247,7 @@ private struct HTMLRenderer: MarkupVisitor {
 	}
 
 	mutating func visitLineBreak(_ lineBreak: LineBreak) {
-		output += "<br>"
+		output += "<br\(voidClose)"
 	}
 
 	// MARK: - Tables

--- a/Sources/SwiftTextRender/Painter.swift
+++ b/Sources/SwiftTextRender/Painter.swift
@@ -63,6 +63,28 @@ public final class Painter {
 		stream.endPath()
 	}
 
+	/// The column-coordinate range this page shows (y-down).
+	private var sliceTop: Double { geometry.columnTop }
+	private var sliceBottom: Double { geometry.columnTop + geometry.sliceHeightPx }
+
+	/// Whether a box occupying column rows `[top, top + height]` is at least
+	/// partly on this page — used to prune whole subtrees (and their draw
+	/// operators) that fall outside the slice. Without this, every page's content
+	/// stream would carry the entire document's drawing, making a paginated
+	/// render O(pages × document) in both time and output size.
+	private func blockIntersectsSlice(top: Double, height: Double) -> Bool {
+		top + height >= sliceTop - 0.5 && top <= sliceBottom + 0.5
+	}
+
+	/// Whether a line whose top sits at column `top` belongs to this page.
+	/// Pagination breaks at line boundaries, so each line has exactly one home
+	/// page: the slice whose half-open `[top, bottom)` range contains its top.
+	/// Keying on the top (rather than an inclusive overlap) avoids painting a
+	/// boundary line as a clipped sliver on the preceding page too.
+	private func lineOnThisPage(_ top: Double) -> Bool {
+		top >= sliceTop - 0.5 && top < sliceBottom - 0.5
+	}
+
 	/// Page y (from page top) for a column y-coordinate.
 	private func pageY(_ columnY: Double) -> Double {
 		geometry.marginPx + (columnY - geometry.columnTop)
@@ -76,12 +98,16 @@ public final class Painter {
 	/// Paint the box tree onto this page.
 	public func paint(_ box: Box) {
 		if let block = box as? BlockBox {
+			// Skip boxes (and their subtrees) that lie entirely off this page. In
+			// normal flow a child's extent is contained by its parent's, so pruning
+			// a non-intersecting block can't drop visible descendants.
+			guard blockIntersectsSlice(top: block.y, height: block.height) else { return }
 			paintBackground(block)
 			paintBorders(block)
 			if let image = block.image {
 				paintImage(block, image: image)
 			} else if block.establishesInlineContext {
-				for line in block.lines {
+				for line in block.lines where lineOnThisPage(line.y) {
 					for fragment in line.fragments {
 						paintText(fragment)
 					}

--- a/Tests/SwiftTextEPUBTests/EpubTestSupport.swift
+++ b/Tests/SwiftTextEPUBTests/EpubTestSupport.swift
@@ -5,6 +5,10 @@
 //  XML well-formedness check used across the EPUB tests.
 
 import Foundation
+// On non-Apple platforms XMLParser lives in the separate FoundationXML module.
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
 import Testing
 @testable import SwiftTextEPUB
 

--- a/Tests/SwiftTextEPUBTests/EpubTestSupport.swift
+++ b/Tests/SwiftTextEPUBTests/EpubTestSupport.swift
@@ -1,0 +1,59 @@
+//  EpubTestSupport.swift
+//  SwiftTextEPUBTests
+//
+//  Shared helpers: a fixed metadata factory for deterministic output and an
+//  XML well-formedness check used across the EPUB tests.
+
+import Foundation
+import Testing
+@testable import SwiftTextEPUB
+
+/// Metadata with a pinned identifier and date so output is reproducible.
+func fixedMetadata(
+	title: String = "Test Book",
+	authors: [String] = ["A. Writer"],
+	language: String = "en",
+	coverImage: Data? = nil,
+	coverImageFilename: String? = nil
+) -> EpubMetadata {
+	EpubMetadata(
+		title: title,
+		authors: authors,
+		language: language,
+		identifier: "urn:uuid:00000000-0000-0000-0000-000000000000",
+		modified: Date(timeIntervalSince1970: 1_700_000_000),
+		coverImage: coverImage,
+		coverImageFilename: coverImageFilename)
+}
+
+/// Returns the file at `path` from a built file list, or fails the test.
+func file(_ files: [EpubFile], _ path: String, sourceLocation: SourceLocation = #_sourceLocation) -> EpubFile? {
+	let match = files.first { $0.path == path }
+	if match == nil { Issue.record("missing container file: \(path)", sourceLocation: sourceLocation) }
+	return match
+}
+
+/// The UTF-8 string content of a container file.
+func string(_ file: EpubFile?) -> String {
+	guard let file else { return "" }
+	return String(decoding: file.data, as: UTF8.self)
+}
+
+/// Asserts a string parses as well-formed XML.
+func expectWellFormedXML(_ xml: String, _ label: String, sourceLocation: SourceLocation = #_sourceLocation) {
+	let parser = XMLParser(data: Data(xml.utf8))
+	let delegate = StrictXMLDelegate()
+	parser.delegate = delegate
+	let ok = parser.parse()
+	if !ok || delegate.error != nil {
+		let detail = delegate.error.map { "\($0)" } ?? "\(parser.parserError.map { "\($0)" } ?? "unknown")"
+		Issue.record("\(label) is not well-formed XML: \(detail)", sourceLocation: sourceLocation)
+	}
+}
+
+private final class StrictXMLDelegate: NSObject, XMLParserDelegate {
+	var error: Error?
+	func parser(_ parser: XMLParser, parseErrorOccurred parseError: Error) {
+		error = parseError
+	}
+}

--- a/Tests/SwiftTextEPUBTests/EpubTests.swift
+++ b/Tests/SwiftTextEPUBTests/EpubTests.swift
@@ -1,0 +1,209 @@
+//  EpubTests.swift
+//  SwiftTextEPUBTests
+
+import Foundation
+import Testing
+@testable import SwiftTextEPUB
+
+@Suite("Markdown → EPUB")
+struct EpubTests {
+
+	// A minimal valid 1×1 PNG, for cover tests.
+	static let onePixelPNG = Data(base64Encoded:
+		"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==")!
+
+	// MARK: - OCF container
+
+	@Test("mimetype is the first entry, stored, with the exact media type")
+	func mimetypeFirst() {
+		let files = MarkdownToEpub.makeFiles("# Chapter\n\nBody.", metadata: fixedMetadata(), options: EpubOptions())
+		let first = files.first
+		#expect(first?.path == "mimetype")
+		#expect(first?.compression == .stored)
+		#expect(string(first) == "application/epub+zip")
+	}
+
+	@Test("the built archive puts mimetype first and stored (byte level)")
+	func archiveMimetypeBytes() throws {
+		let data = try MarkdownToEpub.makeData("# Chapter\n\nBody.", metadata: fixedMetadata(), options: EpubOptions())
+		let bytes = [UInt8](data)
+		// Local file header signature "PK\x03\x04".
+		#expect(Array(bytes[0..<4]) == [0x50, 0x4B, 0x03, 0x04])
+		// Compression method (offset 8, little-endian) == 0 (stored).
+		#expect(UInt16(bytes[8]) | UInt16(bytes[9]) << 8 == 0)
+		let nameLen = Int(UInt16(bytes[26]) | UInt16(bytes[27]) << 8)
+		let extraLen = Int(UInt16(bytes[28]) | UInt16(bytes[29]) << 8)
+		let name = String(decoding: bytes[30 ..< 30 + nameLen], as: UTF8.self)
+		#expect(name == "mimetype")
+		let payloadStart = 30 + nameLen + extraLen
+		let payload = String(decoding: bytes[payloadStart ..< payloadStart + 20], as: UTF8.self)
+		#expect(payload == "application/epub+zip")
+	}
+
+	@Test("container.xml points at the package document")
+	func containerXML() {
+		let files = MarkdownToEpub.makeFiles("# A\n\nx", metadata: fixedMetadata(), options: EpubOptions())
+		let container = string(file(files, "META-INF/container.xml"))
+		expectWellFormedXML(container, "container.xml")
+		#expect(container.contains("full-path=\"OEBPS/content.opf\""))
+		#expect(container.contains("media-type=\"application/oebps-package+xml\""))
+	}
+
+	// MARK: - Package document
+
+	@Test("OPF carries the Dublin Core metadata")
+	func opfMetadata() {
+		let metadata = fixedMetadata(title: "The Book", authors: ["Jane Doe", "John Roe"], language: "de")
+		let files = MarkdownToEpub.makeFiles("# One\n\nx", metadata: metadata, options: EpubOptions())
+		let opf = string(file(files, "OEBPS/content.opf"))
+		expectWellFormedXML(opf, "content.opf")
+		#expect(opf.contains("<dc:title>The Book</dc:title>"))
+		#expect(opf.contains("<dc:language>de</dc:language>"))
+		#expect(opf.contains("<dc:creator id=\"creator-1\">Jane Doe</dc:creator>"))
+		#expect(opf.contains("<dc:creator id=\"creator-2\">John Roe</dc:creator>"))
+		#expect(opf.contains("scheme=\"marc:relators\">aut</meta>"))
+		#expect(opf.contains("<dc:identifier id=\"pub-id\">urn:uuid:00000000-0000-0000-0000-000000000000</dc:identifier>"))
+		#expect(opf.contains("<meta property=\"dcterms:modified\">2023-11-14T22:13:20Z</meta>"))
+		#expect(opf.contains("unique-identifier=\"pub-id\""))
+	}
+
+	@Test("metadata with XML-special characters is escaped")
+	func metadataEscaping() {
+		let metadata = fixedMetadata(title: "Tom & Jerry <3", authors: ["A \"Quote\" Smith"])
+		let files = MarkdownToEpub.makeFiles("# One\n\nx", metadata: metadata, options: EpubOptions())
+		let opf = string(file(files, "OEBPS/content.opf"))
+		expectWellFormedXML(opf, "content.opf with specials")
+		#expect(opf.contains("Tom &amp; Jerry &lt;3"))
+	}
+
+	// MARK: - Chapter splitting
+
+	@Test("splits into one file per heading at the chosen level")
+	func splitsAtLevel() {
+		let markdown = "# One\n\naa\n\n# Two\n\nbb\n\n# Three\n\ncc"
+		let files = MarkdownToEpub.makeFiles(markdown, metadata: fixedMetadata(), options: EpubOptions(chapterLevel: 1))
+		let chapterFiles = files.filter { $0.path.hasPrefix("OEBPS/text/ch") }
+		#expect(chapterFiles.count == 3)
+		let nav = string(file(files, "OEBPS/nav.xhtml"))
+		#expect(nav.contains(">One</a>"))
+		#expect(nav.contains(">Two</a>"))
+		#expect(nav.contains(">Three</a>"))
+	}
+
+	@Test("a chapter's leading headings are combined into its title")
+	func combinedTitles() {
+		let markdown = "# Book\n\n## 1\n\n### The Birthday\n\nprose\n\n## 2\n\n### The Journey\n\nprose"
+		let files = MarkdownToEpub.makeFiles(markdown, metadata: fixedMetadata(), options: EpubOptions(chapterLevel: 2))
+		let nav = string(file(files, "OEBPS/nav.xhtml"))
+		#expect(nav.contains("1: The Birthday"))
+		#expect(nav.contains("2: The Journey"))
+	}
+
+	@Test("content before the first chapter heading becomes front matter, kept out of the TOC")
+	func frontMatter() {
+		let markdown = "# Book Title\n\n*subtitle*\n\n> epigraph\n\n## Chapter One\n\nprose"
+		let files = MarkdownToEpub.makeFiles(markdown, metadata: fixedMetadata(), options: EpubOptions(chapterLevel: 2))
+		let nav = string(file(files, "OEBPS/nav.xhtml"))
+		// The front-matter section holds the leading material…
+		let front = string(file(files, "OEBPS/text/ch001.xhtml"))
+		#expect(front.contains("epub:type=\"frontmatter\""))
+		#expect(front.contains("epigraph"))
+		// …but only the real chapter appears in the reading-order TOC.
+		#expect(nav.contains(">Chapter One</a>"))
+		#expect(!nav.contains("epigraph"))
+		let ncx = string(file(files, "OEBPS/toc.ncx"))
+		#expect(ncx.components(separatedBy: "<navPoint").count - 1 == 1)
+	}
+
+	@Test("a document with no headings still yields one navigable chapter")
+	func noHeadings() {
+		let files = MarkdownToEpub.makeFiles("Just a paragraph.\n\nAnd another.", metadata: fixedMetadata(title: "Solo"), options: EpubOptions())
+		let nav = string(file(files, "OEBPS/nav.xhtml"))
+		expectWellFormedXML(nav, "nav.xhtml")
+		#expect(nav.contains(">Solo</a>"))
+		#expect(file(files, "OEBPS/text/ch001.xhtml") != nil)
+	}
+
+	// MARK: - Content documents
+
+	@Test("chapter bodies are well-formed XHTML with self-closed void elements")
+	func chapterXHTMLWellFormed() {
+		let markdown = "# Chapter\n\nA line.\n\n---\n\nAfter a scene break.\n\nHard\\\nbreak."
+		let files = MarkdownToEpub.makeFiles(markdown, metadata: fixedMetadata(), options: EpubOptions())
+		let chapter = string(file(files, "OEBPS/text/ch001.xhtml"))
+		expectWellFormedXML(chapter, "chapter")
+		#expect(chapter.contains("<hr />"))
+		#expect(chapter.contains("<br />"))
+	}
+
+	@Test("a code block with special characters in its info string stays well-formed")
+	func codeBlockLanguageStaysWellFormed() {
+		let markdown = "# Chapter\n\n```xml&<\"bad\n<tag/>\n```\n"
+		let files = MarkdownToEpub.makeFiles(markdown, metadata: fixedMetadata(), options: EpubOptions())
+		expectWellFormedXML(string(file(files, "OEBPS/text/ch001.xhtml")), "chapter with special code language")
+	}
+
+	@Test("every generated XML/XHTML document is well-formed")
+	func everythingWellFormed() {
+		let markdown = "# One\n\ntext with <angle> & ampersand\n\n## Sub\n\n```c++\nx < y && a\n```\n\n# Two\n\nx"
+		let files = MarkdownToEpub.makeFiles(markdown, metadata: fixedMetadata(coverImage: Self.onePixelPNG, coverImageFilename: "c.png"), options: EpubOptions(chapterLevel: 1))
+		for file in files where file.path.hasSuffix(".xhtml") || file.path.hasSuffix(".opf") || file.path.hasSuffix(".ncx") || file.path.hasSuffix(".xml") {
+			expectWellFormedXML(String(decoding: file.data, as: UTF8.self), file.path)
+		}
+	}
+
+	// MARK: - Cover
+
+	@Test("a cover image is embedded and wired into the manifest and spine")
+	func coverEmbedded() {
+		let files = MarkdownToEpub.makeFiles("# A\n\nx", metadata: fixedMetadata(coverImage: Self.onePixelPNG, coverImageFilename: "cover.png"), options: EpubOptions())
+		// Image bytes stored (already compressed), correct media type.
+		let image = file(files, "OEBPS/images/cover.png")
+		#expect(image?.compression == .stored)
+		let opf = string(file(files, "OEBPS/content.opf"))
+		#expect(opf.contains("media-type=\"image/png\""))
+		#expect(opf.contains("properties=\"cover-image\""))
+		#expect(opf.contains("<itemref idref=\"cover\" linear=\"no\"/>"))
+		let coverPage = string(file(files, "OEBPS/text/cover.xhtml"))
+		expectWellFormedXML(coverPage, "cover.xhtml")
+		// 1×1 PNG → dimensions known → SVG wrapper.
+		#expect(coverPage.contains("<svg"))
+		#expect(coverPage.contains("viewBox=\"0 0 1 1\""))
+		#expect(opf.contains("<meta name=\"cover\" content=\"cover-image\"/>"))
+	}
+
+	@Test("no cover means no cover files or spine entry")
+	func noCover() {
+		let files = MarkdownToEpub.makeFiles("# A\n\nx", metadata: fixedMetadata(), options: EpubOptions())
+		#expect(!files.contains { $0.path == "OEBPS/text/cover.xhtml" })
+		#expect(!files.contains { $0.path.hasPrefix("OEBPS/images/") })
+		let opf = string(file(files, "OEBPS/content.opf"))
+		#expect(!opf.contains("cover-image"))
+	}
+
+	// MARK: - Stylesheet
+
+	@Test("user CSS is appended after the default stylesheet")
+	func userCSSAppended() {
+		let css = "p { color: rebeccapurple; }"
+		let files = MarkdownToEpub.makeFiles("# A\n\nx", metadata: fixedMetadata(), options: EpubOptions(userCSS: css))
+		let stylesheet = string(file(files, "OEBPS/styles/stylesheet.css"))
+		#expect(stylesheet.contains("SwiftText EPUB base stylesheet"))
+		#expect(stylesheet.contains("rebeccapurple"))
+		// Appended after (so author rules win on equal specificity).
+		let defaultIndex = stylesheet.range(of: "base stylesheet")!.lowerBound
+		let userIndex = stylesheet.range(of: "rebeccapurple")!.lowerBound
+		#expect(defaultIndex < userIndex)
+	}
+
+	// MARK: - Determinism
+
+	@Test("the same input and metadata produce byte-identical archives")
+	func deterministic() throws {
+		let markdown = "# One\n\naa\n\n# Two\n\nbb"
+		let metadata = fixedMetadata(coverImage: Self.onePixelPNG, coverImageFilename: "c.png")
+		let a = try MarkdownToEpub.makeData(markdown, metadata: metadata, options: EpubOptions())
+		let b = try MarkdownToEpub.makeData(markdown, metadata: metadata, options: EpubOptions())
+		#expect(a == b)
+	}
+}

--- a/Tests/SwiftTextMarkdownTests/SwiftMarkdownHTMLRendererTests.swift
+++ b/Tests/SwiftTextMarkdownTests/SwiftMarkdownHTMLRendererTests.swift
@@ -191,4 +191,32 @@ struct SwiftMarkdownHTMLRendererTests {
 		let html = SwiftMarkdownHTMLRenderer.convert(#"a -- b --- c ... "quoted""#)
 		#expect(html == ##"<p>a -- b --- c ... "quoted"</p>"##)
 	}
+
+	@Test func xhtmlModeSelfClosesVoidElements() {
+		// EPUB content documents are parsed as XHTML, so void elements must be
+		// self-closed and boolean attributes given their XHTML form.
+		let hr = SwiftMarkdownHTMLRenderer.convert("a\n\n---\n\nb", options: .xhtml)
+		#expect(hr.contains("<hr />"))
+		let br = SwiftMarkdownHTMLRenderer.convert("a\\\nb", options: .xhtml)
+		#expect(br.contains("<br />"))
+		let img = SwiftMarkdownHTMLRenderer.convert("![alt](x.png)", options: .xhtml)
+		#expect(img.contains("<img src=\"x.png\" alt=\"alt\" />"))
+		let task = SwiftMarkdownHTMLRenderer.convert("- [x] done\n- [ ] todo", options: .xhtml)
+		#expect(task.contains(#"<input type="checkbox" disabled="disabled" checked="checked" />"#))
+		#expect(task.contains(#"<input type="checkbox" disabled="disabled" />"#))
+	}
+
+	@Test func defaultModeKeepsHTML5VoidElements() {
+		// Without the option, output is unchanged (HTML5 void-element shape).
+		#expect(SwiftMarkdownHTMLRenderer.convert("a\n\n---\n\nb").contains("<hr>"))
+		#expect(SwiftMarkdownHTMLRenderer.convert("![alt](x.png)").contains("<img src=\"x.png\" alt=\"alt\">"))
+	}
+
+	@Test func codeBlockLanguageIsAttributeEscaped() {
+		// A code-fence info string with XML-special characters must be escaped in
+		// the class attribute, or the fragment isn't well-formed XHTML.
+		let html = SwiftMarkdownHTMLRenderer.convert("```xml&<\"bad\ncode\n```")
+		#expect(html.contains("class=\"language-xml&amp;&lt;&quot;bad\""))
+		#expect(!html.contains("language-xml&<"))
+	}
 }

--- a/Tests/SwiftTextRenderTests/RenderPDFTests.swift
+++ b/Tests/SwiftTextRenderTests/RenderPDFTests.swift
@@ -85,15 +85,14 @@ struct RenderPDFTests {
 		// in the output exactly once. Before slice-culling, the painter emitted
 		// the entire document's draw operators into every page's content stream
 		// (relying on the clip to hide them), so this marker appeared once per
-		// page and output size grew quadratically. Base-14 text is drawn as a
-		// literal `(…)` string in an uncompressed stream, so a raw byte scan
-		// counts how many times it was actually painted.
+		// page and output size grew quadratically. Render uncompressed so base-14
+		// text stays a literal `(…)` string a raw byte scan can count.
 		var html = "<body><p>UNIQUEMARKERWORD sits at the very top.</p>"
 		for index in 0 ..< 400 {
 			html += "<p>Filler paragraph number \(index) to force pagination across many pages.</p>"
 		}
 		html += "</body>"
-		let data = try await HTMLRenderer.renderPDF(html: html)
+		let data = try await HTMLRenderer.renderPDF(html: html, options: RenderOptions(compressStreams: false))
 
 		#if canImport(PDFKit)
 		#expect(try #require(PDFDocument(data: data)).pageCount > 5)

--- a/Tests/SwiftTextRenderTests/RenderPDFTests.swift
+++ b/Tests/SwiftTextRenderTests/RenderPDFTests.swift
@@ -79,6 +79,37 @@ struct RenderPDFTests {
 		#endif
 	}
 
+	@Test("Each page paints only its own slice, not the whole document (O(n²) guard)")
+	func pagesDoNotDuplicateWholeDocument() async throws {
+		// A word painted near the top of a long, multi-page document must appear
+		// in the output exactly once. Before slice-culling, the painter emitted
+		// the entire document's draw operators into every page's content stream
+		// (relying on the clip to hide them), so this marker appeared once per
+		// page and output size grew quadratically. Base-14 text is drawn as a
+		// literal `(…)` string in an uncompressed stream, so a raw byte scan
+		// counts how many times it was actually painted.
+		var html = "<body><p>UNIQUEMARKERWORD sits at the very top.</p>"
+		for index in 0 ..< 400 {
+			html += "<p>Filler paragraph number \(index) to force pagination across many pages.</p>"
+		}
+		html += "</body>"
+		let data = try await HTMLRenderer.renderPDF(html: html)
+
+		#if canImport(PDFKit)
+		#expect(try #require(PDFDocument(data: data)).pageCount > 5)
+		#endif
+
+		let needle = Array("UNIQUEMARKERWORD".utf8)
+		let haystack = [UInt8](data)
+		var count = 0
+		if needle.count <= haystack.count {
+			for start in 0 ... (haystack.count - needle.count) where Array(haystack[start ..< start + needle.count]) == needle {
+				count += 1
+			}
+		}
+		#expect(count == 1)
+	}
+
 	#if os(macOS)
 	@Test("Registered OpenType fonts are embedded (CIDFontType2)")
 	func embedsOpenTypeFont() async throws {


### PR DESCRIPTION
## Summary

Adds native **Markdown → EPUB 3** export to `swifttext render` (closes #41) — the in-house equivalent of `pandoc -o book.epub`, so a manuscript + cover + metadata no longer needs a second toolchain. Also fixes a pre-existing **O(n²)** blowup in the cross-platform PDF engine that made large manuscripts unusable (found while validating the "epub *and* pdf from one manuscript" workflow).

Validated end-to-end on a real 89k-word manuscript: the EPUB passes **`epubcheck` 5.3 (EPUB 3.3) with 0 errors / 0 warnings**, and both outputs now build in seconds.

## EPUB feature

New `SwiftTextEPUB` module, same shape as `SwiftTextDOCX`/`SwiftTextPages` (walk the swift-markdown AST → build the format's files → zip):

- **Chapters** split at a configurable heading level (`--chapter-level`, default `h1`); leading content becomes a front-matter section kept out of the TOC. A chapter's nav label combines its run of leading headings (`## 1` + `### The Birthday…` → *"1: The Birthday…"*), matching the reference EPUB's TOC quality.
- **Full OCF container**: `mimetype` first + stored (per spec), `container.xml`, OPF 3.0 (Dublin Core metadata + manifest + spine), EPUB 3 nav + legacy NCX, a generated title page, an aspect-fit SVG cover page, one XHTML content document per chapter. Deterministic given fixed metadata.
- **Cover** (`--cover`, format-sniffed) and **`--css`** (shared flag applied to HTML, PDF, and EPUB).
- Book-quality reading stylesheet (serif, justified, first-line indents, scene-break rule, chapter page breaks, centered title page).

CLI: `swifttext render book.md -o book.epub` with `--title`/`--author`/`--language`/`--chapter-level`; title inferred from the first heading (skipping code fences).

Renderer: added an opt-in `.xhtml` `Options` flag to `SwiftMarkdownHTMLRenderer` that self-closes void elements and emits XHTML boolean attributes, so chapter bodies are well-formed XML. Also fixed a latent unescaped code-fence info string (`class="language-…"`) — a bug in the HTML path too.

Package: new `SwiftTextEPUB` target/product behind an `EPUB` trait (CLI enables it transitively); ZIPFoundation single-trait-gated like DOCX/Pages; excluded from the portable subset.

## O(n²) PDF-engine fix

The `--engine swift` painter emitted the *entire* document's draw operators into *every* page's content stream, relying on the per-page clip to hide off-page content — O(pages × document). An 800-paragraph synthetic doc produced a **95 MB** PDF; the real manuscript timed out past 120 s. The painter now culls to each page's column slice (skip off-slice subtrees and lines). Output is linear: 95 MB → 2 MB for that doc, and the manuscript renders in ~4 s.

## Test plan

- [x] `swift test` — **472 pass** (~22 new: EPUB structure/spec/escaping/determinism, renderer XHTML mode, and an O(n²) regression guard verified to fail without the fix).
- [x] `swiftlint` clean; both default and `SWIFTTEXT_PORTABLE_ONLY=1` manifests resolve.
- [x] Real 89k-word manuscript: EPUB `epubcheck`-clean; EPUB ~1 s, swift-engine PDF ~4 s.
- [x] A 10-agent adversarial review of the EPUB code found 5 issues (1 XHTML-escaping bug, 1 title-inference robustness bug, 3 help-text inaccuracies) — all fixed and re-verified.

Docs: README + new `Docs/EPUB.md`.

Note: the swift-engine PDF is ~8 MB vs ~950 KB for webkit/EPUB because `SwiftTextPDFWriter` writes uncompressed content streams — a separate optimization (`FlateDecode`), out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)