### PR TITLE
Fix Pages ordered list numbering restarts

### DIFF
--- a/Sources/SwiftTextPages/MarkdownToPages.swift
+++ b/Sources/SwiftTextPages/MarkdownToPages.swift
@@ -209,6 +209,7 @@ private struct BlockVisitor: MarkupVisitor {
 	var paragraphs: [BodyParagraph] = []
 	var footnoteDefinitions: [String: String] = [:]
 	private var listDepth = 0
+	private var nextListInstance = 1
 	private var blockQuoteDepth = 0
 
 	mutating func defaultVisit(_ markup: Markup) {
@@ -282,22 +283,24 @@ private struct BlockVisitor: MarkupVisitor {
 	}
 
 	mutating func visitUnorderedList(_ unorderedList: UnorderedList) {
-		emitListItems(in: unorderedList, ordered: false)
+		emitListItems(in: unorderedList, ordered: false, listInstance: nil)
 	}
 
 	mutating func visitOrderedList(_ orderedList: OrderedList) {
-		emitListItems(in: orderedList, ordered: true)
+		let listInstance = nextListInstance
+		nextListInstance += 1
+		emitListItems(in: orderedList, ordered: true, listInstance: listInstance)
 	}
 
-	private mutating func emitListItems(in list: ListItemContainer, ordered: Bool) {
+	private mutating func emitListItems(in list: ListItemContainer, ordered: Bool, listInstance: Int?) {
 		let level = listDepth
 		for child in list.children {
 			guard let item = child as? ListItem else { continue }
-			emit(listItem: item, ordered: ordered, level: level)
+			emit(listItem: item, ordered: ordered, level: level, listInstance: listInstance)
 		}
 	}
 
-	private mutating func emit(listItem: ListItem, ordered: Bool, level: Int) {
+	private mutating func emit(listItem: ListItem, ordered: Bool, level: Int, listInstance: Int?) {
 		var inlineParagraphs: [Paragraph] = []
 		var nestedLists: [Markup] = []
 		for child in listItem.children {
@@ -318,6 +321,7 @@ private struct BlockVisitor: MarkupVisitor {
 			paragraphStyle: PagesStyleID.body,
 			listStyle: ordered ? PagesStyleID.numberedList : PagesStyleID.bulletList,
 			listLevel: level,
+			listInstance: ordered ? listInstance : nil,
 			runs: collector.runs,
 			links: collector.links
 		))

--- a/Sources/SwiftTextPages/PagesBodyBuilder.swift
+++ b/Sources/SwiftTextPages/PagesBodyBuilder.swift
@@ -76,6 +76,9 @@ struct BodyParagraph {
 	var listStyle: UInt64?
 	/// Nesting depth for list items (0-based); ignored when not a list.
 	var listLevel: Int = 0
+	/// Logical ordered-list container identity, used to keep one Markdown list on
+	/// one Pages list instance even when nested lists interrupt its item stream.
+	var listInstance: Int?
 	/// Whether the paragraph is block-quoted (rendered indented + italic).
 	var blockQuote: Bool = false
 	/// For an attachment paragraph (a single `U+FFFC`), the drawable-attachment
@@ -122,10 +125,9 @@ struct BodyParagraph {
 	}
 }
 
-/// Resolves `InlineStyle` combinations to character-style object ids, synthesizing
-/// new `TSWP.CharacterStyleArchive` objects for combinations the template lacks
-/// (anything beyond a single built-in bold/italic/strikethrough).
-final class CharacterStyleRegistry {
+/// Allocates body-scoped objects referenced from run tables: synthesized
+/// character styles, hyperlink smart fields, and anonymous list styles.
+final class BodyObjectRegistry {
 	private var nextID = PagesStyleID.synthesizedBase
 	private var cache: [InlineStyle: UInt64] = [:]
 	private(set) var synthesizedObjects: [IWAObject] = []
@@ -166,6 +168,20 @@ final class CharacterStyleRegistry {
 		return id
 	}
 
+	/// A fresh numbered-list style inheriting the captured template's numbered
+	/// style. Pages treats the style object identity as the list instance, so
+	/// separate Markdown lists need separate anonymous styles to restart at 1.
+	func numberedListStyleInstance() -> UInt64 {
+		let id = nextID
+		nextID += 1
+		synthesizedObjects.append(IWAObject(
+			identifier: id,
+			type: 2023,
+			payload: Self.inheritedListStylePayload(parent: PagesStyleID.numberedList)
+		))
+		return id
+	}
+
 	private static func hyperlinkPayload(url: String) -> [UInt8] {
 		// #1 = { #1: a unique smart-field UUID }, #2 = the destination URL.
 		var fieldIdentifier = ProtobufWriter()
@@ -173,6 +189,18 @@ final class CharacterStyleRegistry {
 		var archive = ProtobufWriter()
 		archive.messageField(1, fieldIdentifier.bytes)
 		archive.stringField(2, url)
+		return archive.bytes
+	}
+
+	private static func inheritedListStylePayload(parent parentID: UInt64) -> [UInt8] {
+		var parentReference = ProtobufWriter()
+		parentReference.varintField(1, parentID)
+
+		var styleSuper = ProtobufWriter()
+		styleSuper.messageField(3, parentReference.bytes)     // TSS.StyleArchive.parent
+
+		var archive = ProtobufWriter()
+		archive.messageField(1, styleSuper.bytes)             // TSWP.ListStyleArchive.super
 		return archive.bytes
 	}
 
@@ -188,7 +216,7 @@ final class CharacterStyleRegistry {
 		parentReference.varintField(1, PagesStyleID.stylesheet)
 		var styleSuper = ProtobufWriter()
 		styleSuper.stringField(1, styleName(for: style))    // TSS.StyleArchive.name
-		styleSuper.messageField(5, parentReference.bytes)   // TSS.StyleArchive.parent
+		styleSuper.messageField(5, parentReference.bytes)   // TSS.StyleArchive.stylesheet
 
 		var charProperties = ProtobufWriter()
 		if style.bold { charProperties.varintField(1, 1) }
@@ -233,7 +261,7 @@ enum PagesBodySerializer {
 	/// The paragraph separator iWork uses inside a storage's text.
 	static let paragraphSeparator = "\u{2029}"
 
-	static func body(from paragraphs: [BodyParagraph], templatePayload: [UInt8], registry: CharacterStyleRegistry, footnoteMarkIDs: [UInt64] = [], footnoteCharStyleID: UInt64? = nil) -> [UInt8] {
+	static func body(from paragraphs: [BodyParagraph], templatePayload: [UInt8], registry: BodyObjectRegistry, footnoteMarkIDs: [UInt64] = [], footnoteCharStyleID: UInt64? = nil) -> [UInt8] {
 		// 1. Assemble the full text and each paragraph's UTF-16 start offset.
 		var fullText = ""
 		var paragraphStarts = [Int]()
@@ -252,12 +280,29 @@ enum PagesBodySerializer {
 		var paragraphStyleEntries = [(index: Int, styleID: UInt64?)]()
 		var paragraphDataEntries = [(index: Int, level: Int)]()
 		var listStyleEntries = [(index: Int, styleID: UInt64?)]()
+		var numberedListStylesByInstance = [Int: UInt64]()
+		var activeOrderedListStyle: UInt64?
 		for (index, paragraph) in paragraphs.enumerated() {
 			let start = paragraphStarts[index]
 			let styleID = paragraph.blockQuote ? PagesStyleID.blockQuote : paragraph.paragraphStyle
 			paragraphStyleEntries.append((start, styleID))
 			paragraphDataEntries.append((start, paragraph.listLevel))
-			listStyleEntries.append((start, paragraph.listStyle ?? PagesStyleID.listNone))
+			let listStyle = paragraph.listStyle ?? PagesStyleID.listNone
+			if listStyle == PagesStyleID.numberedList {
+				if let listInstance = paragraph.listInstance {
+					let instanceStyle = numberedListStylesByInstance[listInstance] ?? registry.numberedListStyleInstance()
+					numberedListStylesByInstance[listInstance] = instanceStyle
+					listStyleEntries.append((start, instanceStyle))
+				} else {
+					if activeOrderedListStyle == nil {
+						activeOrderedListStyle = registry.numberedListStyleInstance()
+					}
+					listStyleEntries.append((start, activeOrderedListStyle))
+				}
+			} else {
+				activeOrderedListStyle = nil
+				listStyleEntries.append((start, listStyle))
+			}
 		}
 
 		// 3. Character-style run table (#8). Pages writes this as a partition that

--- a/Sources/SwiftTextPages/PagesSynthesizer.swift
+++ b/Sources/SwiftTextPages/PagesSynthesizer.swift
@@ -35,7 +35,7 @@ public final class PagesSynthesizer {
 		guard let bodyStorageID = bodyStorageIdentifier() else { throw PagesWriteError.bodyStorageNotFound }
 		guard let templatePayload = payload(of: bodyStorageID) else { throw PagesWriteError.bodyStorageNotFound }
 
-		let registry = CharacterStyleRegistry()
+		let registry = BodyObjectRegistry()
 		let newBody = PagesBodySerializer.body(from: paragraphs, templatePayload: templatePayload, registry: registry)
 		graph.replacePayload(of: bodyStorageID, type: 2001, with: newBody)
 

--- a/Sources/SwiftTextPages/PagesWriter.swift
+++ b/Sources/SwiftTextPages/PagesWriter.swift
@@ -36,7 +36,7 @@ public final class PagesWriter {
 	/// paragraph style, list membership, and inline style runs).
 	func write(paragraphs inputParagraphs: [BodyParagraph], baseURL: URL? = nil, to url: URL) throws {
 		let identity = DocumentIdentity.fresh()
-		let registry = CharacterStyleRegistry()
+		let registry = BodyObjectRegistry()
 
 		// Native tables: build the object set for every table paragraph and inject it
 		// into the captured components (the grid lives in `Index/Tables/*`, the model
@@ -106,7 +106,7 @@ public final class PagesWriter {
 				                         footnoteCharStyleID: footnoteArtifacts?.charStyleID)
 			case "Index/DocumentStylesheet.iwa":
 				data = try applyingStylesheet(to: data)
-			case "Index/Metadata.iwa" where tableArtifacts != nil || imageArtifacts != nil || footnoteArtifacts != nil:
+			case "Index/Metadata.iwa" where registry.didSynthesize || tableArtifacts != nil || imageArtifacts != nil || footnoteArtifacts != nil:
 				// Document.iwa is processed earlier in this loop, so `registry` already
 				// reflects any synthesized objects by the time Metadata is written.
 				let synthesizedMax = registry.didSynthesize ? registry.maxIdentifier : 0
@@ -119,9 +119,9 @@ public final class PagesWriter {
 						styleComponentRefs: tableArtifacts.styleComponentRefs
 					)
 				}
-				if imageArtifacts != nil || footnoteArtifacts != nil {
+				if registry.didSynthesize || imageArtifacts != nil || footnoteArtifacts != nil {
 					// Register embedded image media (DataInfo #4) + raise the object-id mark
-					// to cover the appended image/footnote objects.
+					// to cover the appended body/image/footnote objects.
 					data = try addingImageMetadata(to: data, dataInfos: imageArtifacts?.dataInfos ?? [],
 					                                highWaterMark: newMax)
 				}
@@ -203,7 +203,7 @@ public final class PagesWriter {
 	private func buildDocument(
 		from documentIWA: [UInt8],
 		paragraphs: [BodyParagraph],
-		registry: CharacterStyleRegistry,
+		registry: BodyObjectRegistry,
 		extraObjects: [IWAObject] = [],
 		footnoteMarkIDs: [UInt64] = [],
 		footnoteCharStyleID: UInt64? = nil

--- a/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
@@ -94,6 +94,40 @@ struct DocxWriterTests {
 		#expect(xml.contains("rLink1"))
 	}
 
+	@Test("Separated Markdown ordered lists use distinct DOCX numbering instances")
+	func separatedOrderedListsUseDistinctNumberingInstances() throws {
+		let markdown = """
+		### Term A
+
+		Definition A
+
+		1. collocation A1
+		2. collocation A2
+
+		### Term B
+
+		Definition B
+
+		1. collocation B1
+		2. collocation B2
+		"""
+
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("md-list-restart-\(UUID().uuidString).docx")
+		defer { try? FileManager.default.removeItem(at: url) }
+
+		try MarkdownToDocx.convert(markdown, to: url)
+
+		let archive = try #require(Archive(url: url, accessMode: .read))
+		var documentData = Data()
+		let entry = try #require(archive["word/document.xml"])
+		_ = try archive.extract(entry) { documentData.append($0) }
+		let xml = String(data: documentData, encoding: .utf8)!
+
+		#expect(xml.components(separatedBy: #"<w:numId w:val="1"/>"#).count - 1 == 2)
+		#expect(xml.components(separatedBy: #"<w:numId w:val="2"/>"#).count - 1 == 2)
+	}
+
 	@Test("Markdown table headers preserve strikethrough")
 	func markdownTableHeaderStrikethrough() throws {
 		let markdown = """

--- a/Tests/SwiftTextHTMLTests/MarkdownToHTMLTests.swift
+++ b/Tests/SwiftTextHTMLTests/MarkdownToHTMLTests.swift
@@ -77,6 +77,27 @@ struct MarkdownToHTMLTests {
 		#expect(html.contains("<li>First</li>"))
 	}
 
+	@Test func separatedOrderedListsRenderAsSeparateElements() {
+		let input = """
+		### Term A
+
+		Definition A
+
+		1. collocation A1
+		2. collocation A2
+
+		### Term B
+
+		Definition B
+
+		1. collocation B1
+		2. collocation B2
+		"""
+		let html = MarkdownToHTML.convert(input)
+		#expect(html.components(separatedBy: "<ol>").count - 1 == 2)
+		#expect(!html.contains("<ol start"))
+	}
+
 	@Test func fencedCodeBlock() {
 		let input = "```\nlet x = 1\n```"
 		let html = MarkdownToHTML.convert(input)

--- a/Tests/SwiftTextPagesTests/MarkdownToPagesTests.swift
+++ b/Tests/SwiftTextPagesTests/MarkdownToPagesTests.swift
@@ -255,6 +255,90 @@ struct MarkdownToPagesTests {
 		#expect(try PagesFile(url: url).markdown().contains("**bold**"))
 	}
 
+	@Test("Separated ordered Markdown lists use separate Pages list instances")
+	func separatedOrderedListsUseSeparateNumberingStyles() throws {
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("swifttext-lists-\(UUID().uuidString).pages")
+		defer { try? FileManager.default.removeItem(at: url) }
+		let markdown = """
+		### Term A
+
+		Definition A
+
+		1. collocation A1
+		2. collocation A2
+		3. collocation A3
+
+		### Term B
+
+		Definition B
+
+		1. collocation B1
+		2. collocation B2
+		3. collocation B3
+		"""
+		try MarkdownToPages.convert(markdown, to: url)
+
+		let store = try objectStore(at: url)
+		let body = try #require(store.objects(ofType: 2001).first {
+			(ProtobufMessage($0.payload).bytes(3).map { String(decoding: $0, as: UTF8.self) } ?? "")
+				.contains("collocation A1")
+		})
+		let listStyleIDs = ProtobufMessage(body.payload)
+			.message(7)?
+			.messages(1)
+			.compactMap { $0.message(2)?.varint(1) }
+			.filter { $0 != PagesStyleID.listNone } ?? []
+
+		#expect(listStyleIDs.count == 6)
+		let firstListIDs = Array(listStyleIDs.prefix(3))
+		let secondListIDs = Array(listStyleIDs.suffix(3))
+		let firstStyle = try #require(firstListIDs.first)
+		let secondStyle = try #require(secondListIDs.first)
+		#expect(firstStyle != secondStyle)
+		#expect(firstListIDs.allSatisfy { $0 == firstStyle })
+		#expect(secondListIDs.allSatisfy { $0 == secondStyle })
+
+		for styleID in [firstStyle, secondStyle] {
+			let object = try #require(store.object(styleID))
+			#expect(object.type == 2023)
+			let parent = ProtobufMessage(object.payload).message(1)?.message(3)?.varint(1)
+			#expect(parent == PagesStyleID.numberedList)
+		}
+
+		let metadata = try #require(store.objects(ofType: 11006).first)
+		let highWaterMark = ProtobufMessage(metadata.payload).varint(1) ?? 0
+		#expect(highWaterMark >= (listStyleIDs.max() ?? 0))
+	}
+
+	@Test("Nested unordered lists do not restart the parent ordered list instance")
+	func nestedUnorderedListKeepsParentNumberingStyle() throws {
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("swifttext-mixed-list-\(UUID().uuidString).pages")
+		defer { try? FileManager.default.removeItem(at: url) }
+		let markdown = """
+		1. One
+		   - detail
+		2. Two
+		"""
+		try MarkdownToPages.convert(markdown, to: url)
+
+		let store = try objectStore(at: url)
+		let body = try #require(store.objects(ofType: 2001).first {
+			(ProtobufMessage($0.payload).bytes(3).map { String(decoding: $0, as: UTF8.self) } ?? "")
+				.contains("detail")
+		})
+		let orderedStyleIDs = ProtobufMessage(body.payload)
+			.message(7)?
+			.messages(1)
+			.compactMap { $0.message(2)?.varint(1) }
+			.filter { $0 != PagesStyleID.listNone && $0 != PagesStyleID.bulletList } ?? []
+
+		#expect(orderedStyleIDs.count == 2)
+		let firstStyle = try #require(orderedStyleIDs.first)
+		#expect(orderedStyleIDs.allSatisfy { $0 == firstStyle })
+	}
+
 	/// Loads every `Index/*.iwa` object from a written `.pages` into one store.
 	private func objectStore(at url: URL) throws -> IWAObjectStore {
 		var store = IWAObjectStore()


### PR DESCRIPTION
Resolves #47.

Summary:
- Give each Markdown ordered-list container its own inherited Pages list-style instance so separated lists restart at 1.
- Preserve parent ordered-list continuity when nested unordered lists interrupt the item stream.
- Add regression coverage for Pages, plus HTML and DOCX checks for separated ordered lists.

Verification:
- `swift test --filter "separatedOrderedLists|nestedUnorderedListKeepsParentNumberingStyle" --scratch-path /Volumes/SSD/SwiftPM/SwiftText-issue-47`
- MissionControl `verify_build` build gate passed.