### PR TITLE
Preserve paragraph-style formatting (bold, headings, list numbering) in Pages extraction

### DIFF
--- a/Sources/SwiftTextCLI/SwiftTextCLI.swift
+++ b/Sources/SwiftTextCLI/SwiftTextCLI.swift
@@ -683,7 +683,12 @@ struct Pages: AsyncParsableCommand {
 		}
 
 		let pages = try PagesFile(url: fileURL)
-		let output = markdown ? pages.markdown() : pages.plainText()
+		// Writing to a .md file implies Markdown, matching how `render` infers its
+		// format from the -o extension — plain text into report.md is never intended.
+		let extensionImpliesMarkdown = outputPath.map {
+			["md", "markdown"].contains(URL(fileURLWithPath: $0).pathExtension.lowercased())
+		} ?? false
+		let output = markdown || extensionImpliesMarkdown ? pages.markdown() : pages.plainText()
 		if !output.isEmpty {
 			try writeOutputIfNeeded(output)
 		}

--- a/Sources/SwiftTextPages/PagesDocument.swift
+++ b/Sources/SwiftTextPages/PagesDocument.swift
@@ -181,7 +181,23 @@ public struct PagesDocument {
 		/// surrounding whitespace is trimmed. When `applyingEmphasis` is set, runs
 		/// are wrapped in `**`/`*`/`***`; when `inliningImages` is set, image
 		/// anchors become `![](reference)` (both off for plain text).
-		func renderedText(inliningImages: Bool, applyingEmphasis: Bool) -> String {
+		/// `suppressingUniformEmphasis` drops any emphasis that covers the entire
+		/// paragraph uniformly — that styling restates the paragraph's own style
+		/// (a bold heading style, say) rather than marking up a span within it, so
+		/// headings render as `## Section`, not `## **Section**`; spans that
+		/// differ from the rest still get their markers.
+		func renderedText(inliningImages: Bool, applyingEmphasis: Bool, suppressingUniformEmphasis: Bool = false) -> String {
+			var suppressBold = false
+			var suppressItalic = false
+			var suppressStrike = false
+			var suppressCode = false
+			if suppressingUniformEmphasis, let first = emphasis.first, first.start <= 0 {
+				suppressBold = emphasis.allSatisfy(\.bold)
+				suppressItalic = emphasis.allSatisfy(\.italic)
+				suppressStrike = emphasis.allSatisfy(\.strike)
+				suppressCode = emphasis.allSatisfy(\.code)
+			}
+
 			var output = ""
 			var runText = ""
 			var runBold = false
@@ -206,7 +222,15 @@ public struct PagesDocument {
 
 			func flushRun() {
 				guard !runText.isEmpty else { return }
-				output += applyingEmphasis ? PagesDocument.markedUp(runText, bold: runBold, italic: runItalic, strike: runStrike, code: runCode) : runText
+				output += applyingEmphasis
+					? PagesDocument.markedUp(
+						runText,
+						bold: runBold && !suppressBold,
+						italic: runItalic && !suppressItalic,
+						strike: runStrike && !suppressStrike,
+						code: runCode && !suppressCode
+					)
+					: runText
 				runText = ""
 			}
 
@@ -331,9 +355,32 @@ public struct PagesDocument {
 		return leading + core + trailing
 	}
 
-	/// Returns the normalized text of each non-empty paragraph.
+	/// Returns the normalized text of each non-empty paragraph. List items keep
+	/// their visible marker — the number or bullet Pages draws is document
+	/// content, so plain-text extraction would otherwise silently drop it
+	/// ("Topics: 1. Offer 2. Acceptance" must not flatten into bare lines).
+	/// Numbering follows the same counter rules as `markdown()`.
 	public func plainTextParagraphs() -> [String] {
-		paragraphs.map { $0.normalizedText() }.filter { !$0.isEmpty }
+		var out = [String]()
+		var counters = [Int: Int]()
+		for paragraph in paragraphs {
+			let text = paragraph.normalizedText()
+			guard !text.isEmpty else { continue }
+			guard let level = paragraph.listLevel else {
+				counters.removeAll()
+				out.append(text)
+				continue
+			}
+			let indent = String(repeating: "    ", count: max(level, 0))
+			for deeper in counters.keys where deeper > level { counters[deeper] = nil }
+			if paragraph.listOrdered {
+				counters[level, default: 0] += 1
+				out.append(indent + "\(counters[level]!). " + text)
+			} else {
+				out.append(indent + "• " + text)
+			}
+		}
+		return out
 	}
 
 	/// Returns the document as plain text, paragraphs separated by blank lines.
@@ -399,7 +446,8 @@ public struct PagesDocument {
 				counters.removeAll()
 				let plain = paragraph.normalizedText()
 				if let level = headingLevel(for: paragraph, text: plain, bodySize: bodySize) {
-					lines.append(String(repeating: "#", count: level) + " " + rendered)
+					let heading = paragraph.renderedText(inliningImages: true, applyingEmphasis: true, suppressingUniformEmphasis: true)
+					lines.append(String(repeating: "#", count: level) + " " + heading)
 				} else {
 					lines.append(rendered)
 				}

--- a/Sources/SwiftTextPages/PagesMarkdownAST.swift
+++ b/Sources/SwiftTextPages/PagesMarkdownAST.swift
@@ -50,9 +50,10 @@ extension PagesDocument {
 				continue
 			}
 
-			let inlines = Self.inlineMarkup(of: paragraph)
+			let level = headingLevel(for: paragraph, text: paragraph.normalizedText(), bodySize: bodySize)
+			let inlines = Self.inlineMarkup(of: paragraph, suppressingUniformEmphasis: level != nil)
 			if !inlines.isEmpty {
-				if let level = headingLevel(for: paragraph, text: paragraph.normalizedText(), bodySize: bodySize) {
+				if let level {
 					blocks.append(Heading(level: level, inlines))
 				} else {
 					blocks.append(Markdown.Paragraph(inlines))
@@ -74,8 +75,13 @@ extension PagesDocument {
 	/// The paragraph's inline content as AST nodes. We render the paragraph's inline
 	/// Markdown (text + emphasis/code/link/image/footnote runs) and parse it back, so
 	/// the emphasis nesting and link/image shapes are produced by cmark itself.
-	static func inlineMarkup(of paragraph: Paragraph) -> [InlineMarkup] {
-		inlineChildren(parsing: paragraph.renderedText(inliningImages: true, applyingEmphasis: true))
+	/// Headings pass `suppressingUniformEmphasis` so a bold heading *style* doesn't
+	/// render redundant `**` markers inside the heading.
+	static func inlineMarkup(of paragraph: Paragraph, suppressingUniformEmphasis: Bool = false) -> [InlineMarkup] {
+		inlineChildren(parsing: paragraph.renderedText(
+			inliningImages: true, applyingEmphasis: true,
+			suppressingUniformEmphasis: suppressingUniformEmphasis
+		))
 	}
 
 	/// Parses a fragment of inline Markdown into inline nodes (the children of the first

--- a/Sources/SwiftTextPages/PagesParser.swift
+++ b/Sources/SwiftTextPages/PagesParser.swift
@@ -40,9 +40,13 @@ final class PagesParser {
 		/// Char/paragraph `…StyleArchive.char_properties`.
 		static let charPropertiesField = 11
 		/// Within a paragraph/character style: the `super` TSS.StyleArchive (field 1),
-		/// which carries `name` (field 1) and the stable `style_identifier` (field 2).
+		/// which carries `name` (field 1), the stable `style_identifier` (field 2),
+		/// and the `parent` style reference (field 3) that property lookup falls
+		/// back to — anonymous styles ("Body + bold") override a field or two and
+		/// inherit the rest from the named style they were derived from.
 		static let styleSuperField = 1
 		static let styleIdentifierField = 2
+		static let styleParentField = 3
 		/// Within char properties: bold, italic, strikethrough, and font size.
 		static let boldField = 1
 		static let italicField = 2
@@ -123,6 +127,91 @@ final class PagesParser {
 		case none
 		case bullet
 		case ordered
+	}
+
+	/// The character-level properties a style resolves to. Each field is `nil`
+	/// when neither the style nor any ancestor sets it — for a character style
+	/// that means "inherit from the paragraph"; for a paragraph style it means
+	/// the document default applies.
+	private struct CharStyleFlags {
+		var bold: Bool?
+		var italic: Bool?
+		var strike: Bool?
+		var fontSize: Double?
+		var fontName: String?
+
+		var isComplete: Bool {
+			bold != nil && italic != nil && strike != nil && fontSize != nil && fontName != nil
+		}
+
+		/// Fills any still-unset field from the given `char_properties` message.
+		/// Called walking from the style outward through its ancestors, so the
+		/// nearest style that sets a field wins (proto2 presence semantics: an
+		/// absent field inherits, an explicit 0 overrides).
+		mutating func fill(from properties: ProtobufMessage) {
+			if bold == nil, let value = properties.varint(IWork.boldField) { bold = value != 0 }
+			if italic == nil, let value = properties.varint(IWork.italicField) { italic = value != 0 }
+			if strike == nil, let value = properties.varint(IWork.strikethroughField) { strike = value != 0 }
+			if fontSize == nil, let value = properties.float(IWork.fontSizeField) { fontSize = Double(value) }
+			if fontName == nil, let bytes = properties.bytes(IWork.fontNameField) { fontName = String(decoding: bytes, as: UTF8.self) }
+		}
+	}
+
+	/// Per-document caches for style resolution — the same handful of styles is
+	/// referenced by every run entry, so resolve each chain once.
+	private var charFlagsCache = [UInt64: CharStyleFlags]()
+	private var identifierTraitsCache = [UInt64: (headingLevel: Int?, isCodeBlock: Bool)]()
+
+	/// Resolves the character properties a style defines, following its parent
+	/// chain (`super.parent`) so an anonymous style derived from a named one
+	/// inherits every field it doesn't override itself.
+	private func resolvedCharFlags(forStyle styleID: UInt64, store: IWAObjectStore) -> CharStyleFlags {
+		if let cached = charFlagsCache[styleID] { return cached }
+		var flags = CharStyleFlags()
+		var currentID: UInt64? = styleID
+		var depth = 0
+		var visited = Set<UInt64>()
+		while let id = currentID, depth < 8, !flags.isComplete, visited.insert(id).inserted, let object = store.object(id) {
+			let style = ProtobufMessage(object.payload)
+			if let properties = style.message(IWork.charPropertiesField) {
+				flags.fill(from: properties)
+			}
+			currentID = style.message(IWork.styleSuperField)?
+				.message(IWork.styleParentField)?
+				.varint(IWork.referenceIdentifierField)
+			depth += 1
+		}
+		charFlagsCache[styleID] = flags
+		return flags
+	}
+
+	/// Resolves what a paragraph style's stable `style_identifier` says about the
+	/// paragraph — an explicit heading level or the preformatted code-block style.
+	/// An anonymous style (no identifier of its own — the "Heading 2 + tweaks"
+	/// overrides Pages writes) defers to its parent chain; a style that carries an
+	/// identifier is authoritative, so a named style merely *derived* from a
+	/// heading doesn't become one.
+	private func identifierTraits(forStyle styleID: UInt64, store: IWAObjectStore) -> (headingLevel: Int?, isCodeBlock: Bool) {
+		if let cached = identifierTraitsCache[styleID] { return cached }
+		var traits: (headingLevel: Int?, isCodeBlock: Bool) = (nil, false)
+		var currentID: UInt64? = styleID
+		var depth = 0
+		var visited = Set<UInt64>()
+		while let id = currentID, depth < 8, visited.insert(id).inserted, let object = store.object(id) {
+			let superStyle = ProtobufMessage(object.payload).message(IWork.styleSuperField)
+			if let identifier = superStyle?.bytes(IWork.styleIdentifierField).map({ String(decoding: $0, as: UTF8.self) }) {
+				if identifier == PagesStyleIdentifier.codeBlock {
+					traits = (nil, true)
+				} else if let level = Self.headingLevel(forStyleIdentifier: identifier) {
+					traits = (level, false)
+				}
+				break
+			}
+			currentID = superStyle?.message(IWork.styleParentField)?.varint(IWork.referenceIdentifierField)
+			depth += 1
+		}
+		identifierTraitsCache[styleID] = traits
+		return traits
 	}
 
 	func readDocument(from url: URL) throws -> PagesDocument {
@@ -252,18 +341,24 @@ final class PagesParser {
 		var paragraphStartUTF16 = 0
 		var utf16Offset = 0
 
+		// The paragraph style active at the current offset. Its resolved character
+		// properties are the paragraph's baseline formatting — a paragraph whose
+		// *style* is bold is bold even with no character-style run over it.
+		var paraRunIndex = 0
+		var activeParaStyleID: UInt64?
+		var paragraphBase = CharStyleFlags()
+
 		// Character emphasis carries forward across paragraphs; advance through the
-		// global run table as the offset grows.
+		// global run table as the offset grows. Character styles override only the
+		// fields they set — anything unset falls through to the paragraph baseline.
 		var charRunIndex = 0
-		var activeBold = false
-		var activeItalic = false
-		var activeStrike = false
-		var activeCode = false
+		var activeCharFlags = CharStyleFlags()
+		var activeCharCode = false
 		let linkSpans = self.linkRuns(storage, store: store)
 
 		func flush() {
 			let paragraphText = String(current)
-			let style = resolvedStyle(atUTF16: paragraphStartUTF16, runs: runs, store: store)
+			let style = paragraphStyleInfo(activeParaStyleID, base: paragraphBase, store: store)
 			let (listLevel, listOrdered) = listMembership(atUTF16: paragraphStartUTF16, levels: levels, listStyles: listStyles, store: store)
 			// Clip the global hyperlink spans to this paragraph and rebase to paragraph-
 			// relative UTF-16 offsets.
@@ -295,13 +390,26 @@ final class PagesParser {
 		}
 
 		for scalar in text.unicodeScalars {
+			while paraRunIndex < runs.count, runs[paraRunIndex].index <= utf16Offset {
+				if let styleID = runs[paraRunIndex].styleID, styleID != activeParaStyleID {
+					activeParaStyleID = styleID
+					paragraphBase = resolvedCharFlags(forStyle: styleID, store: store)
+				}
+				paraRunIndex += 1
+			}
 			while charRunIndex < charRuns.count, charRuns[charRunIndex].index <= utf16Offset {
-				activeBold = charRuns[charRunIndex].bold
-				activeItalic = charRuns[charRunIndex].italic
-				activeStrike = charRuns[charRunIndex].strike
-				activeCode = charRuns[charRunIndex].code
+				activeCharFlags = charRuns[charRunIndex].flags
+				activeCharCode = charRuns[charRunIndex].flags.fontName.map(Self.isMonospaceFont) ?? false
 				charRunIndex += 1
 			}
+			// The formatting in effect here: character-style overrides where set,
+			// the paragraph style's own properties otherwise. Monospace (inline
+			// code) is only ever taken from a character style — a document whose
+			// paragraph styles are monospace is typeset that way, not code.
+			let activeBold = activeCharFlags.bold ?? paragraphBase.bold ?? false
+			let activeItalic = activeCharFlags.italic ?? paragraphBase.italic ?? false
+			let activeStrike = activeCharFlags.strike ?? paragraphBase.strike ?? false
+			let activeCode = activeCharCode
 			// Footnote reference marks sit at a character index (no text character);
 			// number them in reading order and record their definitions.
 			while footnoteIndex < footnoteRefs.count, footnoteRefs[footnoteIndex].index <= utf16Offset {
@@ -443,10 +551,22 @@ final class PagesParser {
 	/// Reconstructs a rich cell's Markdown: the cell-storage text with each
 	/// character-emphasis run wrapped in `**`/`*`/`~~` — reusing the body's emphasis
 	/// machinery so inline bold/italic/strikethrough round-trip out of a table cell.
+	/// The cell's own paragraph style is the baseline the character runs override.
 	private func cellMarkdown(_ storage: IWAObject, store: IWAObjectStore) -> String {
 		let text = storageText(storage)
-		let spans = characterRuns(storage, store: store).map {
-			PagesDocument.Paragraph.EmphasisSpan(start: $0.index, bold: $0.bold, italic: $0.italic, strike: $0.strike)
+		let base = paragraphStyleRuns(storage).first(where: { $0.styleID != nil })?.styleID
+			.map { resolvedCharFlags(forStyle: $0, store: store) } ?? CharStyleFlags()
+		var spans = characterRuns(storage, store: store).map {
+			PagesDocument.Paragraph.EmphasisSpan(
+				start: $0.index,
+				bold: $0.flags.bold ?? base.bold ?? false,
+				italic: $0.flags.italic ?? base.italic ?? false,
+				strike: $0.flags.strike ?? base.strike ?? false
+			)
+		}
+		// A cell styled entirely through its paragraph style has no character runs.
+		if spans.isEmpty, base.bold == true || base.italic == true || base.strike == true {
+			spans = [.init(start: 0, bold: base.bold ?? false, italic: base.italic ?? false, strike: base.strike ?? false)]
 		}
 		let paragraph = PagesDocument.Paragraph(text: text, emphasis: spans)
 		return paragraph.renderedText(inliningImages: false, applyingEmphasis: true)
@@ -485,33 +605,15 @@ final class PagesParser {
 		return runs
 	}
 
-	/// Finds the style active at a character index, then resolves its font size,
-	/// bold flag, and — for a faithful Markdown round-trip — an explicit heading
-	/// level read from the paragraph style's stable `style_identifier`.
-	private func resolvedStyle(atUTF16 index: Int, runs: [(index: Int, styleID: UInt64?)], store: IWAObjectStore) -> (fontSize: Double?, bold: Bool, headingLevel: Int?, isCodeBlock: Bool) {
-		var activeStyleID: UInt64?
-		for run in runs {
-			guard run.index <= index else { break }
-			if let styleID = run.styleID { activeStyleID = styleID }
-		}
-		guard let activeStyleID, let styleObject = store.object(activeStyleID) else {
-			return (nil, false, nil, false)
-		}
-		let style = ProtobufMessage(styleObject.payload)
-		// The paragraph style's `super` (TSS.StyleArchive, field 1) carries the stable,
-		// non-localized `style_identifier` (field 2), e.g. "…-paragraphstyle-Heading 2"
-		// or our own "swifttext-code-block" for the preformatted style.
-		let identifier = style.message(IWork.styleSuperField)
-			.flatMap { $0.bytes(IWork.styleIdentifierField) }
-			.map { String(decoding: $0, as: UTF8.self) }
-		let level = identifier.flatMap(Self.headingLevel(forStyleIdentifier:))
-		let isCodeBlock = identifier == PagesStyleIdentifier.codeBlock
-		guard let charProperties = style.message(IWork.charPropertiesField) else {
-			return (nil, false, level, isCodeBlock)
-		}
-		let bold = (charProperties.varint(IWork.boldField) ?? 0) != 0
-		let fontSize = charProperties.float(IWork.fontSizeField).map(Double.init)
-		return (fontSize, bold, level, isCodeBlock)
+	/// The paragraph-level attributes of the style a paragraph is set in: its
+	/// resolved font size and bold flag (both may be inherited through the parent
+	/// chain), plus — for a faithful Markdown round-trip — an explicit heading
+	/// level or code-block marker read from a stable `style_identifier` anywhere
+	/// in the chain.
+	private func paragraphStyleInfo(_ styleID: UInt64?, base: CharStyleFlags, store: IWAObjectStore) -> (fontSize: Double?, bold: Bool, headingLevel: Int?, isCodeBlock: Bool) {
+		guard let styleID else { return (nil, false, nil, false) }
+		let traits = identifierTraits(forStyle: styleID, store: store)
+		return (base.fontSize, base.bold ?? false, traits.headingLevel, traits.isCodeBlock)
 	}
 
 	/// Maps a paragraph style's `style_identifier` to a Markdown heading level so
@@ -529,29 +631,20 @@ final class PagesParser {
 	}
 
 	/// Reads the character-style run table, resolving each run's referenced
-	/// character style to its bold/italic/strikethrough flags and whether it is set
-	/// in a monospace font (which we surface as inline `code`).
-	private func characterRuns(_ storage: IWAObject, store: IWAObjectStore) -> [(index: Int, bold: Bool, italic: Bool, strike: Bool, code: Bool)] {
+	/// character style (through its parent chain) to the flags it sets. A run
+	/// without a reference — or a style that sets nothing — leaves every field
+	/// `nil`, meaning the paragraph style's formatting shows through.
+	private func characterRuns(_ storage: IWAObject, store: IWAObjectStore) -> [(index: Int, flags: CharStyleFlags)] {
 		guard let table = ProtobufMessage(storage.payload).message(IWork.charStyleTableField) else { return [] }
-		var runs = [(index: Int, bold: Bool, italic: Bool, strike: Bool, code: Bool)]()
+		var runs = [(index: Int, flags: CharStyleFlags)]()
 		for entry in table.messages(IWork.runEntryField) {
 			guard let index = entry.varint(IWork.runCharIndexField) else { continue }
-			var bold = false
-			var italic = false
-			var strike = false
-			var code = false
+			var flags = CharStyleFlags()
 			if let reference = entry.message(IWork.runStyleRefField),
-			   let styleID = reference.varint(IWork.referenceIdentifierField),
-			   let styleObject = store.object(styleID),
-			   let charProperties = ProtobufMessage(styleObject.payload).message(IWork.charPropertiesField) {
-				bold = (charProperties.varint(IWork.boldField) ?? 0) != 0
-				italic = (charProperties.varint(IWork.italicField) ?? 0) != 0
-				strike = (charProperties.varint(IWork.strikethroughField) ?? 0) != 0
-				if let font = charProperties.bytes(IWork.fontNameField).map({ String(decoding: $0, as: UTF8.self) }) {
-					code = Self.isMonospaceFont(font)
-				}
+			   let styleID = reference.varint(IWork.referenceIdentifierField) {
+				flags = resolvedCharFlags(forStyle: styleID, store: store)
 			}
-			runs.append((index: Int(index), bold: bold, italic: italic, strike: strike, code: code))
+			runs.append((index: Int(index), flags: flags))
 		}
 		runs.sort { $0.index < $1.index }
 		return runs

--- a/Sources/SwiftTextPages/PagesParser.swift
+++ b/Sources/SwiftTextPages/PagesParser.swift
@@ -551,22 +551,41 @@ final class PagesParser {
 	/// Reconstructs a rich cell's Markdown: the cell-storage text with each
 	/// character-emphasis run wrapped in `**`/`*`/`~~` — reusing the body's emphasis
 	/// machinery so inline bold/italic/strikethrough round-trip out of a table cell.
-	/// The cell's own paragraph style is the baseline the character runs override.
-	private func cellMarkdown(_ storage: IWAObject, store: IWAObjectStore) -> String {
+	/// The paragraph style active at each offset is the baseline the character
+	/// runs override — merged positionally, the way `makeParagraphs` does for body
+	/// text, so a multi-paragraph cell whose styles differ keeps each one.
+	/// Internal (not private) so tests can drive it with a synthesized storage.
+	func cellMarkdown(_ storage: IWAObject, store: IWAObjectStore) -> String {
 		let text = storageText(storage)
-		let base = paragraphStyleRuns(storage).first(where: { $0.styleID != nil })?.styleID
-			.map { resolvedCharFlags(forStyle: $0, store: store) } ?? CharStyleFlags()
-		var spans = characterRuns(storage, store: store).map {
-			PagesDocument.Paragraph.EmphasisSpan(
-				start: $0.index,
-				bold: $0.flags.bold ?? base.bold ?? false,
-				italic: $0.flags.italic ?? base.italic ?? false,
-				strike: $0.flags.strike ?? base.strike ?? false
-			)
-		}
-		// A cell styled entirely through its paragraph style has no character runs.
-		if spans.isEmpty, base.bold == true || base.italic == true || base.strike == true {
-			spans = [.init(start: 0, bold: base.bold ?? false, italic: base.italic ?? false, strike: base.strike ?? false)]
+		let paraRuns = paragraphStyleRuns(storage)
+		let charRuns = characterRuns(storage, store: store)
+
+		var boundaries: Set<Int> = [0]
+		boundaries.formUnion(paraRuns.map(\.index))
+		boundaries.formUnion(charRuns.map(\.index))
+
+		var base = CharStyleFlags()
+		var overrides = CharStyleFlags()
+		var paraIndex = 0
+		var charIndex = 0
+		var spans = [PagesDocument.Paragraph.EmphasisSpan]()
+		for start in boundaries.sorted() {
+			while paraIndex < paraRuns.count, paraRuns[paraIndex].index <= start {
+				if let styleID = paraRuns[paraIndex].styleID {
+					base = resolvedCharFlags(forStyle: styleID, store: store)
+				}
+				paraIndex += 1
+			}
+			while charIndex < charRuns.count, charRuns[charIndex].index <= start {
+				overrides = charRuns[charIndex].flags
+				charIndex += 1
+			}
+			spans.append(.init(
+				start: start,
+				bold: overrides.bold ?? base.bold ?? false,
+				italic: overrides.italic ?? base.italic ?? false,
+				strike: overrides.strike ?? base.strike ?? false
+			))
 		}
 		let paragraph = PagesDocument.Paragraph(text: text, emphasis: spans)
 		return paragraph.renderedText(inliningImages: false, applyingEmphasis: true)

--- a/Tests/SwiftTextPagesTests/PagesDocumentTests.swift
+++ b/Tests/SwiftTextPagesTests/PagesDocumentTests.swift
@@ -104,6 +104,26 @@ struct PagesDocumentTests {
 		""")
 	}
 
+	@Test("Plain text keeps list markers: numbering, bullets, nesting, and resets")
+	func plainTextListMarkers() {
+		let document = PagesDocument(paragraphs: [
+			.init(text: "First", listLevel: 0, listOrdered: true),
+			.init(text: "Second", listLevel: 0, listOrdered: true),
+			.init(text: "Nested", listLevel: 1, listOrdered: false),
+			.init(text: "Third", listLevel: 0, listOrdered: true),
+			.init(text: "Body paragraph."),
+			.init(text: "Restarted", listLevel: 0, listOrdered: true)
+		])
+		#expect(document.plainTextParagraphs() == [
+			"1. First",
+			"2. Second",
+			"    • Nested",
+			"3. Third",
+			"Body paragraph.",
+			"1. Restarted"
+		])
+	}
+
 	@Test("Drops empty paragraphs from output")
 	func dropsEmptyParagraphs() {
 		let document = PagesDocument(paragraphs: [

--- a/Tests/SwiftTextPagesTests/PagesFormattingTests.swift
+++ b/Tests/SwiftTextPagesTests/PagesFormattingTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import Testing
 
 @testable import SwiftTextPages
+import SwiftTextIWA
 
 /// Exercises the reverse-engineered run tables end-to-end (parser → Markdown):
 /// the character-style table (bold/italic) and the list tables (level +
@@ -224,6 +225,28 @@ struct PagesFormattingTests {
 		let markdown = try PagesFile(url: url).markdown()
 		#expect(markdown.hasPrefix("## Section"))
 		#expect(!markdown.contains("**"))
+	}
+
+	@Test("A rich cell keeps distinct paragraph styles across its paragraphs")
+	func cellWithMixedParagraphStyles() throws {
+		// "Plain" in a regular paragraph style, "Bold" in a bold one at offset 6,
+		// with an italic-only character run over it — the paragraph baseline and
+		// the character override must combine per offset, not from one shared base.
+		let text = "Plain\nBold"
+		let paraTable = runTable(5, [(0, 200), (6, 201)])
+		var charTable = [UInt8]()
+		charTable += IWAWriter.bytesField(1, IWAWriter.varintField(1, 0))
+		charTable += IWAWriter.bytesField(1, IWAWriter.varintField(1, 6) + IWAWriter.bytesField(2, IWAWriter.varintField(1, 202)))
+		let payload = IWAWriter.varintField(1, 0) + IWAWriter.stringField(3, text)
+			+ paraTable + IWAWriter.bytesField(8, charTable)
+
+		var store = IWAObjectStore()
+		store.add(IWAObject(identifier: 200, type: 2022, payload: IWAWriter.bytesField(11, IWAWriter.varintField(1, 0))))
+		store.add(IWAObject(identifier: 201, type: 2022, payload: IWAWriter.bytesField(11, IWAWriter.varintField(1, 1))))
+		store.add(IWAObject(identifier: 202, type: 2021, payload: IWAWriter.bytesField(11, IWAWriter.varintField(2, 1))))
+		let cell = IWAObject(identifier: 10, type: 2001, payload: payload)
+
+		#expect(PagesParser().cellMarkdown(cell, store: store) == "Plain\n***Bold***")
 	}
 
 	@Test("Numbered list with an anonymous style inheriting its marker from a parent")

--- a/Tests/SwiftTextPagesTests/PagesFormattingTests.swift
+++ b/Tests/SwiftTextPagesTests/PagesFormattingTests.swift
@@ -59,7 +59,8 @@ struct PagesFormattingTests {
 		defer { try? FileManager.default.removeItem(at: url) }
 		let pages = try PagesFile(url: url)
 		#expect(pages.markdown() == "Hello **world**\n\n- Item")
-		#expect(pages.plainText() == "Hello world\n\nItem")
+		// Plain text keeps the visible list marker (the bullet Pages draws).
+		#expect(pages.plainText() == "Hello world\n\n• Item")
 	}
 
 	@Test("Strikethrough from the character-style table")
@@ -96,6 +97,135 @@ struct PagesFormattingTests {
 		#expect(try PagesFile(url: url).markdown() == "Claim[^1]\n\n[^1]: the note")
 	}
 
+	@Test("A bold paragraph style renders the whole paragraph bold")
+	func paragraphStyleBold() throws {
+		let text = "Headline\nBody text here."  // second paragraph at offset 9
+
+		let paraTable = runTable(5, [(0, 90), (9, 91)])
+		let body = IWAWriter.varintField(1, 0) + IWAWriter.stringField(3, text) + paraTable
+
+		let objects: [IWAWriter.Object] = [
+			.init(identifier: 10, type: 2001, payload: body),
+			// Paragraph styles: char_properties (field 11) carrying the bold flag —
+			// no character-style runs at all, like a document styled per paragraph.
+			.init(identifier: 90, type: 2022, payload: IWAWriter.bytesField(11, IWAWriter.varintField(1, 1))),
+			.init(identifier: 91, type: 2022, payload: IWAWriter.bytesField(11, IWAWriter.varintField(1, 0)))
+		]
+
+		let url = try bundle(documentObjects: objects)
+		defer { try? FileManager.default.removeItem(at: url) }
+		let pages = try PagesFile(url: url)
+		#expect(pages.markdown() == "**Headline**\n\nBody text here.")
+		#expect(pages.plainText() == "Headline\n\nBody text here.")
+	}
+
+	@Test("An anonymous paragraph style inherits bold and font size from its parent")
+	func paragraphStyleInheritance() throws {
+		let text = "Warning\nBody text long enough to dominate.\nMore body text at the same size."
+
+		let paraTable = runTable(5, [(0, 92), (8, 91)])
+		let body = IWAWriter.varintField(1, 0) + IWAWriter.stringField(3, text) + paraTable
+
+		// 92 sets nothing itself; its super (field 1) points via parent (field 3)
+		// at 93, which is bold and 28pt — the pattern Pages writes when a user
+		// restyles a paragraph ("Body + tweaks" anonymous styles).
+		let anonymous = IWAWriter.bytesField(1, IWAWriter.bytesField(3, IWAWriter.varintField(1, 93)))
+		let parent = IWAWriter.bytesField(11, IWAWriter.varintField(1, 1) + IWAWriter.floatField(3, 28))
+		let bodyStyle = IWAWriter.bytesField(11, IWAWriter.varintField(1, 0) + IWAWriter.floatField(3, 12))
+
+		let objects: [IWAWriter.Object] = [
+			.init(identifier: 10, type: 2001, payload: body),
+			.init(identifier: 92, type: 2022, payload: anonymous),
+			.init(identifier: 93, type: 2022, payload: parent),
+			.init(identifier: 91, type: 2022, payload: bodyStyle)
+		]
+
+		let url = try bundle(documentObjects: objects)
+		defer { try? FileManager.default.removeItem(at: url) }
+		let markdown = try PagesFile(url: url).markdown()
+		// The inherited 28pt (vs. 12pt body) promotes the paragraph to a heading,
+		// and the inherited bold is suppressed there — not `# **Warning**`.
+		#expect(markdown.hasPrefix("# Warning"))
+		#expect(!markdown.contains("**"))
+	}
+
+	@Test("Character runs override only the fields they set on a bold paragraph")
+	func characterOverridesOnBoldParagraph() throws {
+		let text = "AAAA BBBB CCCC"
+
+		let paraTable = runTable(5, [(0, 90)])
+		// Char runs: inherit, explicitly not-bold at "BBBB", inherit again — the
+		// unreferenced entries fall through to the paragraph's bold.
+		var charTable = [UInt8]()
+		charTable += IWAWriter.bytesField(1, IWAWriter.varintField(1, 0))
+		charTable += IWAWriter.bytesField(1, IWAWriter.varintField(1, 5) + IWAWriter.bytesField(2, IWAWriter.varintField(1, 94)))
+		charTable += IWAWriter.bytesField(1, IWAWriter.varintField(1, 10))
+		let body = IWAWriter.varintField(1, 0) + IWAWriter.stringField(3, text)
+			+ paraTable + IWAWriter.bytesField(8, charTable)
+
+		let objects: [IWAWriter.Object] = [
+			.init(identifier: 10, type: 2001, payload: body),
+			.init(identifier: 90, type: 2022, payload: IWAWriter.bytesField(11, IWAWriter.varintField(1, 1))),
+			// An explicit bold = 0 override (present field wins over the paragraph).
+			.init(identifier: 94, type: 2021, payload: IWAWriter.bytesField(11, IWAWriter.varintField(1, 0)))
+		]
+
+		let url = try bundle(documentObjects: objects)
+		defer { try? FileManager.default.removeItem(at: url) }
+		#expect(try PagesFile(url: url).markdown() == "**AAAA** BBBB **CCCC**")
+	}
+
+	@Test("An italic character run on a bold paragraph combines to bold italic")
+	func italicRunOnBoldParagraph() throws {
+		let text = "AAAA BBBB CCCC"
+
+		let paraTable = runTable(5, [(0, 90)])
+		var charTable = [UInt8]()
+		charTable += IWAWriter.bytesField(1, IWAWriter.varintField(1, 0))
+		charTable += IWAWriter.bytesField(1, IWAWriter.varintField(1, 5) + IWAWriter.bytesField(2, IWAWriter.varintField(1, 95)))
+		charTable += IWAWriter.bytesField(1, IWAWriter.varintField(1, 10))
+		let body = IWAWriter.varintField(1, 0) + IWAWriter.stringField(3, text)
+			+ paraTable + IWAWriter.bytesField(8, charTable)
+
+		let objects: [IWAWriter.Object] = [
+			.init(identifier: 10, type: 2001, payload: body),
+			.init(identifier: 90, type: 2022, payload: IWAWriter.bytesField(11, IWAWriter.varintField(1, 1))),
+			// Sets only italic — bold is absent, so the paragraph's bold shows through.
+			.init(identifier: 95, type: 2021, payload: IWAWriter.bytesField(11, IWAWriter.varintField(2, 1)))
+		]
+
+		let url = try bundle(documentObjects: objects)
+		defer { try? FileManager.default.removeItem(at: url) }
+		#expect(try PagesFile(url: url).markdown() == "**AAAA** ***BBBB*** **CCCC**")
+	}
+
+	@Test("A tweaked (anonymous) heading style still maps to a heading via its parent")
+	func headingIdentifierThroughParent() throws {
+		let text = "Section\nBody."
+
+		let paraTable = runTable(5, [(0, 96), (8, 91)])
+		let body = IWAWriter.varintField(1, 0) + IWAWriter.stringField(3, text) + paraTable
+
+		// 96: anonymous, bold tweak, parent 97. 97 carries the stable heading identifier.
+		let anonymous = IWAWriter.bytesField(1, IWAWriter.bytesField(3, IWAWriter.varintField(1, 97)))
+			+ IWAWriter.bytesField(11, IWAWriter.varintField(1, 1))
+		let heading = IWAWriter.bytesField(1, IWAWriter.stringField(2, "text-1-paragraphstyle-Heading 2"))
+			+ IWAWriter.bytesField(11, IWAWriter.varintField(1, 1))
+
+		let objects: [IWAWriter.Object] = [
+			.init(identifier: 10, type: 2001, payload: body),
+			.init(identifier: 96, type: 2022, payload: anonymous),
+			.init(identifier: 97, type: 2022, payload: heading),
+			.init(identifier: 91, type: 2022, payload: [])
+		]
+
+		let url = try bundle(documentObjects: objects)
+		defer { try? FileManager.default.removeItem(at: url) }
+		let markdown = try PagesFile(url: url).markdown()
+		#expect(markdown.hasPrefix("## Section"))
+		#expect(!markdown.contains("**"))
+	}
+
 	@Test("Numbered list with an anonymous style inheriting its marker from a parent")
 	func numberedListWithInheritance() throws {
 		let text = "One\nTwo"  // "Two" at offset 4
@@ -118,6 +248,9 @@ struct PagesFormattingTests {
 
 		let url = try bundle(documentObjects: objects)
 		defer { try? FileManager.default.removeItem(at: url) }
-		#expect(try PagesFile(url: url).markdown() == "1. One\n2. Two")
+		let pages = try PagesFile(url: url)
+		#expect(pages.markdown() == "1. One\n2. Two")
+		// Plain text keeps the visible numbering too.
+		#expect(pages.plainText() == "1. One\n\n2. Two")
 	}
 }


### PR DESCRIPTION
## Problem

Extracting a real-world `.pages` document (styled per paragraph, the way many hand-written documents are) lost most of its visible formatting:

- **Bold paragraphs vanished.** Emphasis was only read from character-style runs (field 8). Documents that carry bold on *paragraph styles* — e.g. anonymous "Body + bold" overrides Pages writes when you select a line and press ⌘B — produced flat text. In the motivating document, every visually-distinct line (title block, `Description`, `Features`, …) is exactly such a paragraph.
- **Style inheritance was ignored.** Properties were read off the referenced style object only. Anonymous styles inherit almost everything from a named parent (`super.parent`), so font sizes and flags resolved to nothing — which also starved the font-size heading heuristic and heading/code-block identifier detection.
- **List numbering disappeared in plain-text mode.** The numbers/bullets Pages draws are generated from list styles, not stored as text, and the default (non-`--markdown`) CLI mode dropped them: `Topics covered include: 1. Offer 2. Acceptance …` flattened into bare lines.

## Fix (all format-general, nothing document-specific)

**Parser** ([PagesParser.swift](Sources/SwiftTextPages/PagesParser.swift))
- Resolve character properties (bold / italic / strikethrough / font size / font name) through the style parent chain, with proto2 presence semantics: an absent field inherits, an explicit `0` overrides. Resolution is cached per style.
- Each paragraph's style provides its **baseline formatting**; character-style runs override only the fields they actually set. Monospace (inline code) still comes only from character styles, so monospace-typeset documents don't become code.
- Heading / code-block `style_identifier`s are found through the parent chain for anonymous styles, so a tweaked `Heading 2` still maps to `##`. A style with its own identifier stays authoritative.
- Table cells get the same baseline treatment.

**Renderer** ([PagesDocument.swift](Sources/SwiftTextPages/PagesDocument.swift), [PagesMarkdownAST.swift](Sources/SwiftTextPages/PagesMarkdownAST.swift))
- Emphasis that covers a heading *uniformly* restates the heading style itself and is suppressed — `## Section`, not `## **Section**`. Partial emphasis inside a heading is kept. Applies to both the string serializer and the AST path.
- Plain text keeps visible list markers with the same counter rules as Markdown: `1. `, `• `, 4-space nesting indents, counters reset at non-list paragraphs.

**CLI** ([SwiftTextCLI.swift](Sources/SwiftTextCLI/SwiftTextCLI.swift))
- `swifttext pages doc.pages -o out.md` now implies `--markdown`, matching how `render` infers its format from the `-o` extension. Plain text into a `.md` file was the likely footgun behind the report.

## Before / after (motivating document)

```markdown
 [legalenglish.me](http://legalenglish.me)
-The Kingdom of Legal English Apps
-Description
+**The Kingdom of Legal English Apps**
+**Description**
 …
```

Plain-text mode now keeps `1.`–`10.` on all three "Topics covered" lists (previously bare lines).

## Tests

Five new end-to-end IWA fixtures (paragraph-style bold, parent-chain inheritance driving bold + the heading heuristic, presence-semantics character overrides incl. explicit un-bold, bold+italic combination, heading identifier via parent) plus a model-level plain-text list-marker test; two existing expectations updated for the intended plain-text change. Full suite: **490 tests, 57 suites, all passing.** Also verified end-to-end against the reporting document: output now matches the document's visible formatting (its bold lines are genuinely paragraph-style bold; `PRACTICAL LEGAL ENGLISH` etc. are plain Body style in the file and stay plain).

Follow-ups deliberately not in this PR: the legacy (iWork ’09 `index.xml`) reader still extracts headings only; `docx`/`keynote` commands could adopt the same `-o` extension inference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)