### PR TITLE
Preserve Pages underline formatting in Markdown

### DIFF
--- a/Sources/SwiftTextPages/MarkdownToPages.swift
+++ b/Sources/SwiftTextPages/MarkdownToPages.swift
@@ -103,6 +103,7 @@ private struct InlineCollector {
 	private(set) var links: [BodyParagraph.LinkSpan] = []
 	private(set) var footnoteRefs: [BodyParagraph.FootnoteRef] = []
 	private var style: InlineStyle
+	private var underlineDepth = 0
 	/// `[^id]: …` definitions; a `[^id]` reference to a defined id becomes a footnote.
 	private let footnoteDefinitions: [String: String]
 
@@ -150,7 +151,16 @@ private struct InlineCollector {
 			imageStyle.italic = true
 			append(alt.isEmpty ? "[image]" : alt, style: imageStyle)
 		case let inlineHTML as InlineHTML:
-			append(inlineHTML.rawHTML, style: style)
+			switch inlineHTML.rawHTML.lowercased() {
+			case "<u>":
+				underlineDepth += 1
+				style.underline = true
+			case "</u>":
+				underlineDepth = max(underlineDepth - 1, 0)
+				style.underline = underlineDepth > 0
+			default:
+				append(inlineHTML.rawHTML, style: style)
+			}
 		case is SoftBreak:
 			append(" ", style: style)          // join soft-wrapped lines with a space
 		case is LineBreak:

--- a/Sources/SwiftTextPages/PagesBodyBuilder.swift
+++ b/Sources/SwiftTextPages/PagesBodyBuilder.swift
@@ -59,11 +59,12 @@ enum PagesStyleIdentifier {
 struct InlineStyle: Hashable {
 	var bold = false
 	var italic = false
+	var underline = false
 	var strikethrough = false
 	var code = false
 	var link = false
 
-	var isPlain: Bool { !bold && !italic && !strikethrough && !code && !link }
+	var isPlain: Bool { !bold && !italic && !underline && !strikethrough && !code && !link }
 }
 
 /// One paragraph of body content destined for the document's text storage.
@@ -139,11 +140,11 @@ final class BodyObjectRegistry {
 
 		// Reuse a built-in style for a single property.
 		let builtIn: UInt64?
-		switch (style.bold, style.italic, style.strikethrough, style.code, style.link) {
-		case (true, false, false, false, false): builtIn = PagesStyleID.boldChar
-		case (false, true, false, false, false): builtIn = PagesStyleID.italicChar
-		case (false, false, true, false, false): builtIn = PagesStyleID.strikethroughChar
-		case (false, false, false, false, true): builtIn = PagesStyleID.linkChar
+		switch (style.bold, style.italic, style.underline, style.strikethrough, style.code, style.link) {
+		case (true, false, false, false, false, false): builtIn = PagesStyleID.boldChar
+		case (false, true, false, false, false, false): builtIn = PagesStyleID.italicChar
+		case (false, false, false, true, false, false): builtIn = PagesStyleID.strikethroughChar
+		case (false, false, false, false, false, true): builtIn = PagesStyleID.linkChar
 		default: builtIn = nil
 		}
 		if let builtIn {
@@ -221,7 +222,7 @@ final class BodyObjectRegistry {
 		var charProperties = ProtobufWriter()
 		if style.bold { charProperties.varintField(1, 1) }
 		if style.italic { charProperties.varintField(2, 1) }
-		if style.link { charProperties.varintField(11, 1) }              // underline
+		if style.underline || style.link { charProperties.varintField(11, 1) }
 		if style.strikethrough { charProperties.varintField(12, 1) }
 		if style.code {
 			charProperties.stringField(5, "Menlo-Regular")              // monospace font
@@ -246,6 +247,7 @@ final class BodyObjectRegistry {
 		var parts = [String]()
 		if style.bold { parts.append("Bold") }
 		if style.italic { parts.append("Italic") }
+		if style.underline { parts.append("Underline") }
 		if style.strikethrough { parts.append("Strikethrough") }
 		if style.code { parts.append("Code") }
 		if style.link { parts.append("Link") }

--- a/Sources/SwiftTextPages/PagesDocument.swift
+++ b/Sources/SwiftTextPages/PagesDocument.swift
@@ -150,13 +150,15 @@ public struct PagesDocument {
 			public var start: Int
 			public var bold: Bool
 			public var italic: Bool
+			public var underline: Bool
 			public var strike: Bool
 			public var code: Bool
 
-			public init(start: Int, bold: Bool, italic: Bool, strike: Bool = false, code: Bool = false) {
+			public init(start: Int, bold: Bool, italic: Bool, underline: Bool = false, strike: Bool = false, code: Bool = false) {
 				self.start = start
 				self.bold = bold
 				self.italic = italic
+				self.underline = underline
 				self.strike = strike
 				self.code = code
 			}
@@ -179,7 +181,7 @@ public struct PagesDocument {
 
 		/// Renders the paragraph text: soft line breaks become newlines and
 		/// surrounding whitespace is trimmed. When `applyingEmphasis` is set, runs
-		/// are wrapped in `**`/`*`/`***`; when `inliningImages` is set, image
+		/// are wrapped in `**`/`*`/`***`/`<u>`; when `inliningImages` is set, image
 		/// anchors become `![](reference)` (both off for plain text).
 		/// `suppressingUniformEmphasis` drops any emphasis that covers the entire
 		/// paragraph uniformly — that styling restates the paragraph's own style
@@ -202,6 +204,7 @@ public struct PagesDocument {
 			var runText = ""
 			var runBold = false
 			var runItalic = false
+			var runUnderline = false
 			var runStrike = false
 			var runCode = false
 			var anchorIndex = 0
@@ -210,6 +213,7 @@ public struct PagesDocument {
 			var footnoteIndex = 0
 			var activeBold = false
 			var activeItalic = false
+			var activeUnderline = false
 			var activeStrike = false
 			var activeCode = false
 
@@ -227,6 +231,9 @@ public struct PagesDocument {
 						runText,
 						bold: runBold && !suppressBold,
 						italic: runItalic && !suppressItalic,
+						// A Markdown link already preserves its Pages underline semantically;
+						// avoid redundant `[<u>text</u>](url)` output for link styles.
+						underline: runUnderline && activeLinkEnd == nil,
 						strike: runStrike && !suppressStrike,
 						code: runCode && !suppressCode
 					)
@@ -248,6 +255,7 @@ public struct PagesDocument {
 				while spanIndex < emphasis.count, emphasis[spanIndex].start <= relativeOffset {
 					activeBold = emphasis[spanIndex].bold
 					activeItalic = emphasis[spanIndex].italic
+					activeUnderline = emphasis[spanIndex].underline
 					activeStrike = emphasis[spanIndex].strike
 					activeCode = emphasis[spanIndex].code
 					spanIndex += 1
@@ -286,10 +294,11 @@ public struct PagesDocument {
 					}
 					anchorIndex += 1
 				default:
-					if applyingEmphasis, activeBold != runBold || activeItalic != runItalic || activeStrike != runStrike || activeCode != runCode {
+					if applyingEmphasis, activeBold != runBold || activeItalic != runItalic || activeUnderline != runUnderline || activeStrike != runStrike || activeCode != runCode {
 						flushRun()
 						runBold = activeBold
 						runItalic = activeItalic
+						runUnderline = activeUnderline
 						runStrike = activeStrike
 						runCode = activeCode
 					}
@@ -322,9 +331,10 @@ public struct PagesDocument {
 
 	/// Wraps `text`'s non-whitespace core in the Markdown emphasis markers for the
 	/// given styling, keeping leading/trailing whitespace outside the markers.
-	/// Strikethrough (`~~`) wraps any bold/italic markers.
-	static func markedUp(_ text: String, bold: Bool, italic: Bool, strike: Bool, code: Bool = false) -> String {
-		guard bold || italic || strike || code else { return text }
+	/// Strikethrough (`~~`) wraps any bold/italic markers; underline uses inline
+	/// HTML because Markdown has no native underline syntax.
+	static func markedUp(_ text: String, bold: Bool, italic: Bool, underline: Bool = false, strike: Bool, code: Bool = false) -> String {
+		guard bold || italic || underline || strike || code else { return text }
 		let scalars = Array(text.unicodeScalars)
 		var start = 0
 		while start < scalars.count, CharacterSet.whitespacesAndNewlines.contains(scalars[start]) {
@@ -349,6 +359,9 @@ public struct PagesDocument {
 		}
 		if strike {
 			core = "~~\(core)~~"
+		}
+		if underline {
+			core = "<u>\(core)</u>"
 		}
 		let leading = String(String.UnicodeScalarView(scalars[..<start]))
 		let trailing = String(String.UnicodeScalarView(scalars[end...]))

--- a/Sources/SwiftTextPages/PagesParser.swift
+++ b/Sources/SwiftTextPages/PagesParser.swift
@@ -47,9 +47,10 @@ final class PagesParser {
 		static let styleSuperField = 1
 		static let styleIdentifierField = 2
 		static let styleParentField = 3
-		/// Within char properties: bold, italic, strikethrough, and font size.
+		/// Within char properties: bold, italic, underline, strikethrough, and font size.
 		static let boldField = 1
 		static let italicField = 2
+		static let underlineField = 11
 		static let strikethroughField = 12
 		static let fontSizeField = 3
 		static let fontNameField = 5
@@ -136,12 +137,13 @@ final class PagesParser {
 	private struct CharStyleFlags {
 		var bold: Bool?
 		var italic: Bool?
+		var underline: Bool?
 		var strike: Bool?
 		var fontSize: Double?
 		var fontName: String?
 
 		var isComplete: Bool {
-			bold != nil && italic != nil && strike != nil && fontSize != nil && fontName != nil
+			bold != nil && italic != nil && underline != nil && strike != nil && fontSize != nil && fontName != nil
 		}
 
 		/// Fills any still-unset field from the given `char_properties` message.
@@ -151,6 +153,7 @@ final class PagesParser {
 		mutating func fill(from properties: ProtobufMessage) {
 			if bold == nil, let value = properties.varint(IWork.boldField) { bold = value != 0 }
 			if italic == nil, let value = properties.varint(IWork.italicField) { italic = value != 0 }
+			if underline == nil, let value = properties.varint(IWork.underlineField) { underline = value != 0 }
 			if strike == nil, let value = properties.varint(IWork.strikethroughField) { strike = value != 0 }
 			if fontSize == nil, let value = properties.float(IWork.fontSizeField) { fontSize = Double(value) }
 			if fontName == nil, let bytes = properties.bytes(IWork.fontNameField) { fontName = String(decoding: bytes, as: UTF8.self) }
@@ -312,7 +315,7 @@ final class PagesParser {
 	}
 
 	/// Splits a storage's text into paragraphs, resolving each paragraph's font
-	/// size, inline bold/italic spans, list membership, and the image (if any)
+	/// size, inline bold/italic/underline spans, list membership, and the image (if any)
 	/// behind each inline-attachment anchor.
 	private func makeParagraphs(
 		in text: String, storage: IWAObject, store: IWAObjectStore, catalog: PagesImageCatalog,
@@ -408,6 +411,7 @@ final class PagesParser {
 			// paragraph styles are monospace is typeset that way, not code.
 			let activeBold = activeCharFlags.bold ?? paragraphBase.bold ?? false
 			let activeItalic = activeCharFlags.italic ?? paragraphBase.italic ?? false
+			let activeUnderline = activeCharFlags.underline ?? paragraphBase.underline ?? false
 			let activeStrike = activeCharFlags.strike ?? paragraphBase.strike ?? false
 			let activeCode = activeCharCode
 			// Footnote reference marks sit at a character index (no text character);
@@ -430,9 +434,10 @@ final class PagesParser {
 					if let grid = anchorTables[utf16Offset] { currentTables.append(grid) }
 				}
 				if currentEmphasis.isEmpty || currentEmphasis.last?.bold != activeBold
-					|| currentEmphasis.last?.italic != activeItalic || currentEmphasis.last?.strike != activeStrike
+					|| currentEmphasis.last?.italic != activeItalic || currentEmphasis.last?.underline != activeUnderline
+					|| currentEmphasis.last?.strike != activeStrike
 					|| currentEmphasis.last?.code != activeCode {
-					currentEmphasis.append(.init(start: utf16Offset - paragraphStartUTF16, bold: activeBold, italic: activeItalic, strike: activeStrike, code: activeCode))
+					currentEmphasis.append(.init(start: utf16Offset - paragraphStartUTF16, bold: activeBold, italic: activeItalic, underline: activeUnderline, strike: activeStrike, code: activeCode))
 				}
 				current.append(scalar)
 				utf16Offset += width
@@ -549,8 +554,8 @@ final class PagesParser {
 	}
 
 	/// Reconstructs a rich cell's Markdown: the cell-storage text with each
-	/// character-emphasis run wrapped in `**`/`*`/`~~` — reusing the body's emphasis
-	/// machinery so inline bold/italic/strikethrough round-trip out of a table cell.
+	/// character-emphasis run wrapped in `**`/`*`/`<u>`/`~~` — reusing the body's
+	/// emphasis machinery so rich formatting round-trips out of a table cell.
 	/// The paragraph style active at each offset is the baseline the character
 	/// runs override — merged positionally, the way `makeParagraphs` does for body
 	/// text, so a multi-paragraph cell whose styles differ keeps each one.
@@ -584,6 +589,7 @@ final class PagesParser {
 				start: start,
 				bold: overrides.bold ?? base.bold ?? false,
 				italic: overrides.italic ?? base.italic ?? false,
+				underline: overrides.underline ?? base.underline ?? false,
 				strike: overrides.strike ?? base.strike ?? false
 			))
 		}

--- a/Sources/SwiftTextPages/PagesTableBuilder.swift
+++ b/Sources/SwiftTextPages/PagesTableBuilder.swift
@@ -495,7 +495,7 @@ enum PagesTableBuilder {
 		if style.bold { charProperties.varintField(1, 1) }
 		if style.italic { charProperties.varintField(2, 1) }
 		if style.code { charProperties.stringField(5, "Menlo-Regular") }
-		if style.link { charProperties.varintField(11, 1) }
+		if style.underline || style.link { charProperties.varintField(11, 1) }
 		if style.strikethrough { charProperties.varintField(12, 1) }
 		var w = ProtobufWriter()
 		w.bytesField(1, styleSuper.bytes)

--- a/Tests/SwiftTextPagesTests/MarkdownToPagesTests.swift
+++ b/Tests/SwiftTextPagesTests/MarkdownToPagesTests.swift
@@ -66,6 +66,26 @@ struct MarkdownToPagesTests {
 		#expect(markdown.contains("Pears"))
 	}
 
+	@Test("Extracted underline Markdown re-imports as Pages formatting")
+	func underlineReimports() throws {
+		let source = PagesDocument(paragraphs: [
+			.init(text: "plain under bold", emphasis: [
+				.init(start: 0, bold: false, italic: false),
+				.init(start: 6, bold: false, italic: false, underline: true),
+				.init(start: 12, bold: true, italic: false, underline: true)
+			])
+		])
+		let markdown = source.markdown()
+		#expect(markdown == "plain <u>under</u> <u>**bold**</u>")
+
+		let url = FileManager.default.temporaryDirectory
+			.appendingPathComponent("swifttext-underline-\(UUID().uuidString).pages")
+		defer { try? FileManager.default.removeItem(at: url) }
+		try MarkdownToPages.convert(markdown, to: url)
+
+		#expect(try PagesFile(url: url).markdown() == markdown)
+	}
+
 	@Test("A Markdown table becomes a native iWork table grid that round-trips")
 	func tableProducesNativeGrid() throws {
 		let url = FileManager.default.temporaryDirectory

--- a/Tests/SwiftTextPagesTests/PagesDocumentTests.swift
+++ b/Tests/SwiftTextPagesTests/PagesDocumentTests.swift
@@ -80,6 +80,27 @@ struct PagesDocumentTests {
 		#expect(PagesDocument(paragraphs: [strikeOnly]).plainText() == "xYz")
 	}
 
+	@Test("Preserves underline as inline HTML")
+	func underline() {
+		let paragraph = PagesDocument.Paragraph(text: "plain under bold", emphasis: [
+			.init(start: 0, bold: false, italic: false),
+			.init(start: 6, bold: false, italic: false, underline: true),
+			.init(start: 12, bold: true, italic: false, underline: true)
+		])
+		#expect(PagesDocument(paragraphs: [paragraph]).markdown() == "plain <u>under</u> <u>**bold**</u>")
+		#expect(PagesDocument(paragraphs: [paragraph]).plainText() == "plain under bold")
+	}
+
+	@Test("Does not add redundant underline markup to links")
+	func underlinedLink() {
+		let paragraph = PagesDocument.Paragraph(
+			text: "linked",
+			emphasis: [.init(start: 0, bold: false, italic: false, underline: true)],
+			links: [.init(start: 0, end: 6, url: "https://example.com")]
+		)
+		#expect(PagesDocument(paragraphs: [paragraph]).markdown() == "[linked](https://example.com)")
+	}
+
 	@Test("Renders bullet and numbered lists with nesting, counters, and tight spacing")
 	func listRendering() {
 		let document = PagesDocument(paragraphs: [

--- a/Tests/SwiftTextPagesTests/PagesFormattingTests.swift
+++ b/Tests/SwiftTextPagesTests/PagesFormattingTests.swift
@@ -80,6 +80,21 @@ struct PagesFormattingTests {
 		#expect(try PagesFile(url: url).markdown() == "hi ~~struck~~")
 	}
 
+	@Test("Underline from the character-style table")
+	func underlineFromCharStyle() throws {
+		let text = "plain under plain"
+		let charTable = runTable(8, [(0, 60), (6, 62), (11, 60)])
+		let body = IWAWriter.varintField(1, 0) + IWAWriter.stringField(3, text) + charTable
+		let objects: [IWAWriter.Object] = [
+			.init(identifier: 10, type: 2001, payload: body),
+			.init(identifier: 60, type: 2021, payload: IWAWriter.bytesField(11, IWAWriter.varintField(11, 0))),
+			.init(identifier: 62, type: 2021, payload: IWAWriter.bytesField(11, IWAWriter.varintField(11, 1)))
+		]
+		let url = try bundle(documentObjects: objects)
+		defer { try? FileManager.default.removeItem(at: url) }
+		#expect(try PagesFile(url: url).markdown() == "plain <u>under</u> plain")
+	}
+
 	@Test("Footnote references become [^N] with definitions appended")
 	func footnotes() throws {
 		// Body "Claim" with a footnote mark at offset 5 (end), referencing a


### PR DESCRIPTION
Resolves #50.

## Summary
- decode the Pages character-style underline property through inherited styles
- preserve standalone underline runs as inline `<u>` HTML in Markdown output
- avoid redundant underline markup for hyperlinks, whose Markdown representation already carries link styling
- cover IWA decoding, rendering combinations, plain-text behavior, and hyperlink output with Swift Testing regressions

## Verification
- `swiftlint lint --strict --quiet`
- `swift test --filter SwiftTextPagesTests --scratch-path /Volumes/SSD/SwiftPM/SwiftText-issue-50` (107 tests passed)
- `swift build --build-tests --scratch-path /Volumes/SSD/SwiftPM/SwiftText-issue-50`
- `swift test --skip-build --scratch-path /Volumes/SSD/SwiftPM/SwiftText-issue-50` (494 tests passed)
- extracted the supplied contract and confirmed 15 underline spans are now represented with `<u>`