### PR TITLE
Replace ZIPFoundation with libarchive

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -56,8 +56,11 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       # SwiftTextHTML/SwiftTextRender use XMLKit's libxml2-backed HTMLParser.
-      - name: Install libxml2 dev
-        run: apt-get update && apt-get install -y libxml2-dev pkg-config
+      # zlib1g-dev + libssl-dev back swift-archive's vendored libarchive: the
+      # GzipSupport trait links `-lz` (needed to inflate DEFLATE zip entries, i.e.
+      # every real .docx/.pages) and CArchive links `-lcrypto` on Linux.
+      - name: Install libxml2 + zlib dev
+        run: apt-get update && apt-get install -y libxml2-dev zlib1g-dev libssl-dev pkg-config
       - name: Verify Swift version
         run: swift --version
       - name: Build (Linux)
@@ -117,7 +120,7 @@ jobs:
 
   # Windows portable job — runs the pure-Swift unit tests. SWIFTTEXT_PORTABLE_ONLY
   # trims the package to the Foundation + swift-markdown targets, so the
-  # libxml2-backed SwiftTextHTML/SwiftTextRender and the ZIPFoundation-backed
+  # libxml2-backed SwiftTextHTML/SwiftTextRender and the libarchive-backed
   # DOCX/Pages targets are absent — `swift test` builds and runs only what the
   # Windows toolchain satisfies with no vcpkg/libxml2 needed. (The full CLI build
   # with vcpkg is the separate build-windows-cli job below.)
@@ -149,7 +152,7 @@ jobs:
   # Android job — runs the portable unit tests on an x86_64 emulator via
   # skiptools/swift-android-action, which provisions the Swift Android SDK.
   # SWIFTTEXT_PORTABLE_ONLY trims the package to the pure-Swift targets (no
-  # libxml2/ZIPFoundation, which the Android SDK doesn't provide), so the action
+  # libxml2/libarchive, which the Android SDK doesn't provide), so the action
   # can build the test bundle and actually run it under the emulator — proving
   # the Markdown/AttributedString/CSS/OpenType/PDF-writer core works on bionic.
   test-android-portable:
@@ -167,7 +170,7 @@ jobs:
           # together push past that without cleanup.
           free-disk-space: true
           # Build the test bundle and run it on the emulator. With the portable
-          # subset there's no libxml2/ZIPFoundation for the SDK to choke on.
+          # subset there's no libxml2/libarchive for the SDK to choke on.
           run-tests: true
 
   # Windows job — builds and smoke-tests the full `swifttext` CLI. Unlike the
@@ -188,12 +191,13 @@ jobs:
       - name: Install libxml2 + zlib (vcpkg)
         shell: pwsh
         run: |
-          # libxml2 backs SwiftTextHTML/SwiftTextRender; zlib backs ZIPFoundation's
-          # CZLib (the DOCX/Pages readers). vcpkg installs zlib's import lib as z.lib,
-          # which is exactly what ZIPFoundation's `.linkedLibrary("z")` resolves to.
+          # libxml2 backs SwiftTextHTML/SwiftTextRender; zlib backs swift-archive's
+          # vendored libarchive under the GzipSupport trait (the DOCX/Pages readers
+          # need it to inflate DEFLATE zip entries). vcpkg installs zlib's import lib
+          # as z.lib, which is exactly what CArchive's `.linkedLibrary("z")` resolves to.
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install libxml2:x64-windows zlib:x64-windows
           $root = "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows"
-          # vcpkg names zlib's import lib z.lib (which ZIPFoundation's
+          # vcpkg names zlib's import lib z.lib (which CArchive's
           # `.linkedLibrary("z")` wants), but libxml2's headers autolink `zlib.lib`
           # via #pragma comment(lib). Provide both names from the one import lib.
           Copy-Item "$root\lib\z.lib" "$root\lib\zlib.lib" -Force

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -27,8 +27,8 @@ jobs:
       # SwiftTextOCR uses the macOS 26 Vision document-recognition APIs
       # (RecognizeDocumentsRequest / NormalizedRegion), so build with a full Xcode
       # that ships the macOS 26 SDK — a swift.org toolchain layered on an older SDK
-      # can't see those symbols. latest-stable's Swift is 6.2.x, which the package's
-      # single-trait manifest conditions build on fine (they're valid on 6.2 and 6.3).
+      # can't see those symbols. latest-stable currently carries Swift 6.3.x, which
+      # the manifest requires (`swift-tools-version:6.3`, for any-of trait conditions).
       - name: Select newest Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,15 @@
 # Agent Guidelines
 
-- **Platform Target**: Ship features for iOS 26 and newer; avoid relying on deprecated APIs.
+- **Platform Target**: Minimum deployment targets are **macOS 13 / iOS 15 / tvOS 15 / watchOS 10**, declared package-wide in `Package.swift`. They are forced by swift-archive (the libarchive-backed Zip support), not chosen, and `platforms:` applies to every target — so the pure-Swift modules inherit them too. Don't raise them without a reason: every consumer inherits the floor. Avoid relying on deprecated APIs.
+- **Cross-platform**: SwiftText builds on Linux, Windows and Android as well as Apple platforms, and CI covers all of them. Apple-only frameworks (Vision, PDFKit, AppKit, WebKit, `Compression`) belong in macOS-gated targets or behind `#if canImport(…)` — never in the portable core (`SwiftTextCore`, `SwiftTextMarkdown`, `SwiftTextAttributedString`, `SwiftTextPDFWriter`, `SwiftTextOpenType`, `SwiftTextCSS`).
+- **Toolchain**: the manifest declares `swift-tools-version:6.3`; older toolchains can't parse it. It relies on 6.3's any-of `.when(traits:)` semantics.
 - **Concurrency**: Prefer modern Swift structured concurrency (`async`/`await`, `Task`, actors) over legacy completion handlers whenever possible.
 - **Unit Testing**: Use Swift Testing exclusively. Do not introduce or reference XCTest-based tests.
-- **Pluralization**: For any text that needs plural-aware output, rely on Swift's `(inflect: true)` syntax—never the manual `parts == 1 ? "part" : "parts"` pattern.  
-  - Example: `Text("Missing ^[\(missingCount) part](inflect: true)")`
+- **Dependencies**: Prefer implementing format internals in-target over adding a package — Snappy, Protocol Buffers, DEFLATE and the stored-Zip writer are all in-house for this reason. Anything unavoidable is gated behind a per-format trait (`DOCX`/`EPUB`/`PAGES`/`HTML`), so a consumer enabling only some traits never resolves it.
 
+## Testing
 
-Testing
-
-- Use `swift test` for BrickCore changes; target specific work with `swift test --filter SomeSuite/yourTest` to iterate quickly.
+- This is a pure SwiftPM package — there is no Xcode project. Use `swift test`; target specific work with `swift test --filter SomeSuite/yourTest` to iterate quickly.
 - When touching only a handful of files, prefer `swift test --filter FileNameTests` or `swift test --filter SuiteName` to avoid running the entire suite.
-- For UI or app-level changes, build the SwiftUI target with `xcodebuild -project SwiftLEGO.xcodeproj -scheme SwiftLEGO -destination "platform=iOS Simulator,name=iPad (10th generation),OS=latest"` to match the iOS 26 minimum.
-- If you need logs or timing, add `-showBuildTimingSummary` or `-quiet` depending on whether you are triaging failures or doing green runs.
+- To exercise the Foundation-only subset that the Linux/Windows/Android CI jobs run: `SWIFTTEXT_PORTABLE_ONLY=1 swift test`. Note this rewrites `Package.resolved` down to the portable dependency set, so `git checkout Package.resolved` afterwards or the pruned lockfile gets committed.
+- To check that the Apple platform graph still compiles: `xcodebuild build -scheme SwiftText-Package -destination 'generic/platform=iOS' -skipPackagePluginValidation CODE_SIGNING_ALLOWED=NO`.

--- a/Docs/PAGES_WRITING.md
+++ b/Docs/PAGES_WRITING.md
@@ -169,7 +169,7 @@ matches after injection) or add a `ComponentInfo` per new `Tables/` file + bump 
 | Protobuf **encode** | ❌ | — |
 | Real IWA **writer** (uses `Snappy.compress`, multi-chunk) | ❌ | — |
 | `PackageMetadata` rebuild | ❌ | — |
-| Zip **write** + `Metadata/` generation | ❌ | (ZIPFoundation can write) |
+| Zip **write** + `Metadata/` generation | ✅ | `StoredZipWriter.swift` |
 
 `IWATestSupport.IWAWriter` already proves the framing math; it is the seed for a
 real writer, but it emits a single all-literal Snappy block and lives in tests.
@@ -394,8 +394,11 @@ styles by ID) → re-encode **only the changed `.iwa` files** → re-zip, **carr
   know any `TP.*` type number or rebuild `PackageMetadata` for text-only edits.
 - **−** Ships a binary blob; output styling is the template's, not arbitrary.
 - **Zip quirk:** iWork's zip is **STORED (no deflate), no Zip64**; the `.iwa`
-  entries (and any nested `Index.zip`) must be stored, not compressed. ZIPFoundation
-  supports `.none` compression — use it.
+  entries (and any nested `Index.zip`) must be stored, not compressed — and the
+  sizes/CRC live in the local header, which libarchive's always-streaming ZIP
+  writer cannot emit. Hence the hand-rolled `StoredZipWriter`, which also
+  preserves each entry's byte-affecting header fields so a re-written package
+  matches Apple's exactly.
 - Self-sufficiency: the blob is data, needs no new SwiftPM product.
 
 ### B. Synthesize from scratch

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "bcc9b9f962dd28aad051a848fe48a2a01a9dfe870397e11ec5aea7ce8523ffcb",
+  "originHash" : "fa55cc284463a679c703bd91b3b67101e5b119c9d1242ce9a3b4debb47f35cb0",
   "pins" : [
-    {
-      "identity" : "swift-argument-parser",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-argument-parser",
-      "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
-      }
-    },
     {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
@@ -26,23 +17,6 @@
       "state" : {
         "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
         "version" : "0.8.0"
-      }
-    },
-    {
-      "identity" : "xmlkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Cocoanetics/XMLKit.git",
-      "state" : {
-        "revision" : "af0be5973bae9a20f4ea2ed3e39401e22a4212cb",
-        "version" : "1.0.0"
-      }
-    },
-    {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation.git",
-      "state" : {
-        "revision" : "187ee77287ea4b23df4d7de32771ec38bbafb840"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "fa55cc284463a679c703bd91b3b67101e5b119c9d1242ce9a3b4debb47f35cb0",
+  "originHash" : "67c4a003c583ea9abab170211764736e9223d7c6e07809adde408c55e6bea945",
   "pins" : [
+    {
+      "identity" : "swift-archive",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/marcprux/swift-archive.git",
+      "state" : {
+        "revision" : "48fddd77a1d8301ce04e0d7c093fcf0867fa1ff8",
+        "version" : "3.8.9"
+      }
+    },
+    {
+      "identity" : "swift-argument-parser",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-argument-parser",
+      "state" : {
+        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
+        "version" : "1.7.0"
+      }
+    },
     {
       "identity" : "swift-cmark",
       "kind" : "remoteSourceControl",
@@ -17,6 +35,15 @@
       "state" : {
         "revision" : "3c6f9523da3a1ec2fd829673e472d95b8097a3b8",
         "version" : "0.8.0"
+      }
+    },
+    {
+      "identity" : "xmlkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Cocoanetics/XMLKit.git",
+      "state" : {
+        "revision" : "af0be5973bae9a20f4ea2ed3e39401e22a4212cb",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.3
 import PackageDescription
 import Foundation
 
@@ -140,9 +140,8 @@ let htmlTargets: [Target] = [
 	.target(
 		name: "SwiftTextHTML",
 		dependencies: [
-			// Single-trait condition, same reasoning as libarchive below. HTML
-			// must be active wherever SwiftTextHTML compiles; the CLI default trait
-			// transitively enables it for plain `swift build`.
+			// HTML must be active wherever SwiftTextHTML compiles; the CLI default
+			// trait transitively enables it for plain `swift build`.
 			.product(name: "HTMLParser", package: "XMLKit", condition: .when(traits: ["HTML"])),
 			"SwiftTextMarkdown",
 			// The HTML→Markdown path builds a swift-markdown AST from the DOM and
@@ -273,10 +272,8 @@ let packageTargets: [Target] = [
 		name: "SwiftTextDOCX",
 		dependencies: [
 			"SwiftTextMarkdown",
-			// Single-trait condition on purpose: Swift 6.2's SwiftPM requires ALL listed
-			// traits to be enabled (6.3 changed this to any-of), so an OR-set like
-			// ["DOCX", "CLI"] would drop libarchive on 6.2 toolchains. The CLI case
-			// is covered by the CLI trait transitively enabling DOCX instead.
+			// DOCX must be active wherever SwiftTextDOCX compiles; the CLI trait
+			// transitively enables it, so listing CLI here would be redundant.
 			.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["DOCX"])),
 			// The libarchive-backed container writer, shared with SwiftTextEPUB.
 			"SwiftTextZip",
@@ -299,24 +296,22 @@ let packageTargets: [Target] = [
 		path: "Sources/SwiftTextEPUB"
 	),
 	// ZIP container *writing* for `.docx` (OPC) and `.epub` (OCF), over libarchive.
-	// Shared by SwiftTextDOCX and SwiftTextEPUB, hence the two conditional entries
-	// for the same product: Swift 6.2's SwiftPM requires ALL traits in one
-	// `.when(traits:)` to be enabled, so OR semantics are spelled as separate
-	// dependencies — either trait alone pulls libarchive in. (iWork writing does
-	// not use this: `.pages` needs byte-exact stored entries, which libarchive's
-	// always-streaming ZIP writer cannot emit — see SwiftTextPages/StoredZipWriter.)
+	// Shared by SwiftTextDOCX and SwiftTextEPUB, so the condition lists both traits
+	// — `.when(traits:)` is any-of as of the 6.3 tools version, so either one alone
+	// pulls libarchive in. (iWork writing does not use this: `.pages` needs
+	// byte-exact stored entries, which libarchive's always-streaming ZIP writer
+	// cannot emit — see SwiftTextPages/StoredZipWriter.)
 	.target(
 		name: "SwiftTextZip",
 		dependencies: [
-			.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["DOCX"])),
-			.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["EPUB"]))
+			.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["DOCX", "EPUB"]))
 		],
 		path: "Sources/SwiftTextZip"
 	),
 	// Shared iWork (IWA) read core. Snappy and Protocol Buffers decoding are
 	// implemented in-target; libarchive (the .iwa container is a Zip archive)
-	// is the only external dependency, gated by PAGES with the same single-trait
-	// reasoning as SwiftTextDOCX — the CLI default trait enables PAGES transitively.
+	// is the only external dependency, gated by PAGES on the same reasoning as
+	// SwiftTextDOCX — the CLI default trait enables PAGES transitively.
 	.target(
 		name: "SwiftTextIWA",
 		dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import Foundation
 
 // When SWIFTTEXT_PORTABLE_ONLY=1, the manifest is trimmed to the pure-Swift,
 // Foundation-only targets and their tests — the surface with no libxml2
-// (SwiftTextHTML / SwiftTextRender) and no ZIPFoundation (SwiftTextDOCX /
+// (SwiftTextHTML / SwiftTextRender) and no libarchive (SwiftTextDOCX /
 // SwiftTextPages) dependency. This lets CI *run* the portable unit tests on
 // platforms where those native dependencies aren't readily available — Windows
 // and the Android cross-compile SDK — instead of only build-checking the
@@ -140,7 +140,7 @@ let htmlTargets: [Target] = [
 	.target(
 		name: "SwiftTextHTML",
 		dependencies: [
-			// Single-trait condition, same reasoning as ZIPFoundation below. HTML
+			// Single-trait condition, same reasoning as libarchive below. HTML
 			// must be active wherever SwiftTextHTML compiles; the CLI default trait
 			// transitively enables it for plain `swift build`.
 			.product(name: "HTMLParser", package: "XMLKit", condition: .when(traits: ["HTML"])),
@@ -275,9 +275,11 @@ let packageTargets: [Target] = [
 			"SwiftTextMarkdown",
 			// Single-trait condition on purpose: Swift 6.2's SwiftPM requires ALL listed
 			// traits to be enabled (6.3 changed this to any-of), so an OR-set like
-			// ["DOCX", "CLI"] would drop ZIPFoundation on 6.2 toolchains. The CLI case
+			// ["DOCX", "CLI"] would drop libarchive on 6.2 toolchains. The CLI case
 			// is covered by the CLI trait transitively enabling DOCX instead.
-			.product(name: "ZIPFoundation", package: "ZIPFoundation", condition: .when(traits: ["DOCX"])),
+			.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["DOCX"])),
+			// The libarchive-backed container writer, shared with SwiftTextEPUB.
+			"SwiftTextZip",
 			// Shared dependency-free utilities (ImageDimensions). No external product,
 			// so no trait condition is needed.
 			"SwiftTextCore"
@@ -289,23 +291,36 @@ let packageTargets: [Target] = [
 		dependencies: [
 			"SwiftTextMarkdown",
 			.product(name: "Markdown", package: "swift-markdown"),
-			// Same single-trait ZIPFoundation gating as SwiftTextDOCX/SwiftTextPages:
-			// the EPUB container is a Zip archive. The CLI default trait enables EPUB
-			// transitively for a plain `swift build`.
-			.product(name: "ZIPFoundation", package: "ZIPFoundation", condition: .when(traits: ["EPUB"])),
+			// The libarchive-backed container writer, shared with SwiftTextDOCX.
+			"SwiftTextZip",
 			// Shared dependency-free utilities (ImageDimensions); see SwiftTextDOCX.
 			"SwiftTextCore"
 		],
 		path: "Sources/SwiftTextEPUB"
 	),
+	// ZIP container *writing* for `.docx` (OPC) and `.epub` (OCF), over libarchive.
+	// Shared by SwiftTextDOCX and SwiftTextEPUB, hence the two conditional entries
+	// for the same product: Swift 6.2's SwiftPM requires ALL traits in one
+	// `.when(traits:)` to be enabled, so OR semantics are spelled as separate
+	// dependencies — either trait alone pulls libarchive in. (iWork writing does
+	// not use this: `.pages` needs byte-exact stored entries, which libarchive's
+	// always-streaming ZIP writer cannot emit — see SwiftTextPages/StoredZipWriter.)
+	.target(
+		name: "SwiftTextZip",
+		dependencies: [
+			.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["DOCX"])),
+			.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["EPUB"]))
+		],
+		path: "Sources/SwiftTextZip"
+	),
 	// Shared iWork (IWA) read core. Snappy and Protocol Buffers decoding are
-	// implemented in-target; ZIPFoundation (the .iwa container is a Zip archive)
+	// implemented in-target; libarchive (the .iwa container is a Zip archive)
 	// is the only external dependency, gated by PAGES with the same single-trait
 	// reasoning as SwiftTextDOCX — the CLI default trait enables PAGES transitively.
 	.target(
 		name: "SwiftTextIWA",
 		dependencies: [
-			.product(name: "ZIPFoundation", package: "ZIPFoundation", condition: .when(traits: ["PAGES"]))
+			.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["PAGES"]))
 		],
 		path: "Sources/SwiftTextIWA"
 	),
@@ -313,7 +328,7 @@ let packageTargets: [Target] = [
 		name: "SwiftTextPages",
 		dependencies: [
 			// The shared IWA read core (Snappy/Protobuf/container/object store/TST
-			// table decoder), which also carries the ZIPFoundation dependency.
+			// table decoder), which also carries the libarchive dependency.
 			"SwiftTextIWA",
 			// Markdown → Pages writing parses with swift-markdown and reuses the
 			// shared plain-text helper. Both are platform-agnostic and always
@@ -341,7 +356,13 @@ let packageTargets: [Target] = [
 	),
 	.testTarget(
 		name: "SwiftTextDOCXTests",
-		dependencies: ["SwiftTextDOCX"],
+		// The tests read written `.docx` files back through libarchive to assert on
+		// their parts, so they link the Archive product directly (same DOCX gating).
+		dependencies: [
+			"SwiftTextDOCX",
+			"SwiftTextZip",
+			.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["DOCX"]))
+		],
 		path: "Tests/SwiftTextDOCXTests",
 		resources: [
 			.process("Resources")
@@ -437,11 +458,11 @@ let allTraits: Set<Trait> = [
 	.trait(name: "PAGES", description: "Pages (iWork) extraction"),
 	// CLI enables DOCX, PAGES, and HTML because SwiftTextCLI links
 	// SwiftTextDOCX, SwiftTextPages, and SwiftTextHTML, whose external products
-	// (ZIPFoundation, XMLKit's HTMLParser) are guarded by those traits.
+	// (libarchive's Archive, XMLKit's HTMLParser) are guarded by those traits.
 	.trait(name: "CLI", description: "swifttext command-line tool dependencies", enabledTraits: ["DOCX", "EPUB", "PAGES", "HTML"]),
 	// "CLI" must be a default trait: the SwiftTextCLI and SwiftTextDOCX targets are
 	// always part of the manifest, so a plain `swift build` needs their external
-	// products (ArgumentParser, ZIPFoundation) active to compile. Consumers that
+	// products (ArgumentParser, Archive) active to compile. Consumers that
 	// specify explicit traits (e.g. ["HTML"]) drop the defaults, which lets SwiftPM
 	// prune both packages from their dependency resolution.
 	.default(enabledTraits: ["OCR", "CLI"])
@@ -449,29 +470,35 @@ let allTraits: Set<Trait> = [
 
 let allDependencies: [Package.Dependency] = [
 	.package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
-	// Pinned to the `development` HEAD for its Windows/Android import fix (the zlib
-	// shim's `#import` → `#include`; weichsel/ZIPFoundation#380). No tagged release
-	// includes it yet, and without it the DOCX/Pages readers can't build on Windows
-	// (clang there rejects `#import` as an MSVC COM directive). Bump back to a
-	// version tag once ZIPFoundation ships a release with the fix.
-	.package(url: "https://github.com/weichsel/ZIPFoundation.git", revision: "187ee77287ea4b23df4d7de32771ec38bbafb840"),
+	// libarchive (vendored as C sources, not a system library) behind a thin Swift
+	// wrapper — the Zip *reader* for the DOCX/EPUB/iWork containers. Replaces
+	// ZIPFoundation, which had to be pinned to an untagged `development` HEAD to
+	// build on Windows (weichsel/ZIPFoundation#380). `GzipSupport` is off by
+	// default upstream but is required here: without zlib, libarchive can't
+	// inflate DEFLATE entries, and every real `.docx`/`.epub` is deflated.
+	.package(url: "https://github.com/marcprux/swift-archive.git", from: "3.8.9", traits: ["GzipSupport"]),
 	.package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.8.0"),
 	.package(url: "https://github.com/Cocoanetics/XMLKit.git", from: "1.0.0")
 ]
 
 // The portable subset needs only swift-markdown; dropping the others keeps the
-// dependency graph clean on platforms without libxml2 / ZIPFoundation toolchains.
+// dependency graph clean on platforms without libxml2 / zlib toolchains.
 let portableDependencies: [Package.Dependency] = [
 	.package(url: "https://github.com/swiftlang/swift-markdown.git", from: "0.8.0")
 ]
 
 let package = Package(
 	name: "SwiftText",
+	// Raised from macOS 12 / iOS 13 / tvOS 13 / watchOS 6 by the swift-archive
+	// (libarchive) dependency, whose own floor is macOS 13 / iOS 15 / tvOS 15 /
+	// watchOS 10. SwiftPM requires a package to be at least as new as any product
+	// it links, and `platforms:` is package-wide, so the pure-Swift targets inherit
+	// the same floor even though they don't link libarchive themselves.
 	platforms: [
-		.macOS(.v12),
-		.iOS(.v13),
-		.tvOS(.v13),
-		.watchOS(.v6)
+		.macOS(.v13),
+		.iOS(.v15),
+		.tvOS(.v15),
+		.watchOS(.v10)
 	],
 	products: portableOnly ? packageProducts.filter { effectivePortableNames.contains($0.name) } : packageProducts,
 	traits: portableOnly ? [] : allTraits,

--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Features:
 ### SwiftTextDOCX
 
 Extracts text and basic structure from DOCX archives using:
-- **ZIPFoundation** to read the Word archive
+- **libarchive** (via [swift-archive](https://github.com/marcprux/swift-archive))
+  to read and write the Word archive
 - **XMLParser** to parse document, styles, and numbering
 
 Features:
@@ -66,7 +67,7 @@ Extracts text and structure from Apple Pages (iWork) documents. The modern
 module decodes them entirely on its own — **no Pages.app, no `textutil`, and no
 Apple frameworks are required**, so it runs on every platform:
 
-- **ZIPFoundation** to read the `.pages` archive (the only external dependency,
+- **libarchive** to read the `.pages` archive (the only external dependency,
   already shared with SwiftTextDOCX)
 - **Snappy** block decompression — implemented in-module
 - **Protocol Buffers** wire decoding — implemented in-module
@@ -133,8 +134,9 @@ Supported features:
 - Smart-punctuation reversal by default (pass `.preserveSmartPunctuation` to keep
   cmark's curly quotes/dashes)
 
-Requires macOS 12 / iOS 15 / tvOS 15 / watchOS 8 (where `AttributedString` is
-available), or any Linux/Windows toolchain bundling swift-foundation.
+Requires `AttributedString`, so it needs macOS 13 / iOS 15 / tvOS 15 / watchOS 10
+(the package floor, which already clears it), or any Linux/Windows toolchain
+bundling swift-foundation.
 
 ```swift
 import SwiftTextAttributedString
@@ -213,7 +215,7 @@ SwiftText defaults to `OCR` plus `CLI` (the dependencies of the bundled `swiftte
 traits: [.defaults, "HTML", "PDF", "DOCX", "PAGES"]
 ```
 
-Listing traits explicitly (without `.defaults`) keeps dependency resolution lean: SwiftPM only fetches the packages the enabled traits actually need. For example, `traits: ["HTML"]` resolves just swift-markdown — neither swift-argument-parser nor ZIPFoundation is fetched or pinned.
+Listing traits explicitly (without `.defaults`) keeps dependency resolution lean: SwiftPM only fetches the packages the enabled traits actually need. For example, `traits: ["HTML"]` resolves just swift-markdown — neither swift-argument-parser nor swift-archive is fetched or pinned.
 
 ## Usage
 
@@ -423,6 +425,9 @@ swifttext overlay --dpi 300 ~/Documents/report.pdf
 ## Requirements
 
 - Swift 5.9+
+- Minimum deployment targets: **macOS 13 / iOS 15 / tvOS 15 / watchOS 10**, set by
+  the libarchive-backed Zip support the DOCX/EPUB/iWork modules link. `platforms:`
+  is package-wide, so it applies even to the pure-Swift modules
 - Library platforms: macOS, iOS, tvOS, watchOS, Linux, Windows (per module; see each module's notes)
 - `swifttext` CLI: macOS, Linux, and Windows
 

--- a/README.md
+++ b/README.md
@@ -424,7 +424,8 @@ swifttext overlay --dpi 300 ~/Documents/report.pdf
 
 ## Requirements
 
-- Swift 5.9+
+- Swift 6.1+ (the manifest declares `swift-tools-version:6.1`; older toolchains
+  can't parse it). CI builds on 6.3
 - Minimum deployment targets: **macOS 13 / iOS 15 / tvOS 15 / watchOS 10**, set by
   the libarchive-backed Zip support the DOCX/EPUB/iWork modules link. `platforms:`
   is package-wide, so it applies even to the pure-Swift modules

--- a/README.md
+++ b/README.md
@@ -424,8 +424,8 @@ swifttext overlay --dpi 300 ~/Documents/report.pdf
 
 ## Requirements
 
-- Swift 6.1+ (the manifest declares `swift-tools-version:6.1`; older toolchains
-  can't parse it). CI builds on 6.3
+- Swift 6.3+ (the manifest declares `swift-tools-version:6.3`; older toolchains
+  can't parse it)
 - Minimum deployment targets: **macOS 13 / iOS 15 / tvOS 15 / watchOS 10**, set by
   the libarchive-backed Zip support the DOCX/EPUB/iWork modules link. `platforms:`
   is package-wide, so it applies even to the pure-Swift modules

--- a/Sources/SwiftTextDOCX/DocxFile.swift
+++ b/Sources/SwiftTextDOCX/DocxFile.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ZIPFoundation
+import Archive
 
 /// A parsed DOCX file with convenience helpers for plain text or Markdown output.
 public final class DocxFile {
@@ -56,9 +56,15 @@ public final class DocxFile {
 		guard FileManager.default.fileExists(atPath: url.path) else {
 			throw DocxFileError.fileNotFound(url)
 		}
-		let archive: Archive
+		let media: [(name: String, data: Data)]
 		do {
-			archive = try Archive(url: url, accessMode: .read)
+			let reader = try ArchiveReader(path: url.path)
+			var found = [(name: String, data: Data)]()
+			try reader.forEachEntry { entry, reader in
+				guard entry.fileType == .regular, entry.pathname.hasPrefix("word/media/") else { return }
+				found.append((URL(fileURLWithPath: entry.pathname).lastPathComponent, try reader.readData()))
+			}
+			media = found
 		} catch {
 			throw DocxFileError.unreadableArchive(url, error)
 		}
@@ -68,15 +74,11 @@ public final class DocxFile {
 
 		var extracted = [URL]()
 		var seenNames: [String: URL] = [:]
-		for entry in archive {
-			guard entry.path.hasPrefix("word/media/"), !entry.path.hasSuffix("/") else { continue }
-			let fileName = URL(fileURLWithPath: entry.path).lastPathComponent
+		for (fileName, data) in media {
 			if let existing = seenNames[fileName] {
 				extracted.append(existing)
 				continue
 			}
-			var data = Data()
-			_ = try archive.extract(entry) { data.append($0) }
 			let outputURL = uniqueDestinationURL(for: fileName, in: destination)
 			try data.write(to: outputURL, options: .atomic)
 			seenNames[fileName] = outputURL

--- a/Sources/SwiftTextDOCX/DocxParser.swift
+++ b/Sources/SwiftTextDOCX/DocxParser.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ZIPFoundation
+import Archive
 #if canImport(FoundationXML)
 // On Linux, XMLParser/XMLParserDelegate live in FoundationXML, not Foundation.
 import FoundationXML
@@ -10,19 +10,27 @@ final class DocxParser {
 		guard FileManager.default.fileExists(atPath: url.path) else {
 			throw DocxFileError.fileNotFound(url)
 		}
-		let archive: Archive
+		// libarchive reads sequentially, so collect every part we might need in a
+		// single pass rather than seeking to each one by name.
+		let wanted: Set<String> = [
+			"word/document.xml", "word/styles.xml", "word/numbering.xml", "word/footnotes.xml"
+		]
+		var parts = [String: Data]()
 		do {
-			archive = try Archive(url: url, accessMode: .read)
+			let reader = try ArchiveReader(path: url.path)
+			try reader.forEachEntry { entry, reader in
+				guard wanted.contains(entry.pathname) else { return }
+				parts[entry.pathname] = try reader.readData()
+			}
 		} catch {
 			throw DocxFileError.unreadableArchive(url, error)
 		}
-		guard let documentEntry = archive["word/document.xml"] else {
+		guard let documentData = parts["word/document.xml"] else {
 			throw DocxFileError.missingDocumentXML
 		}
-		let documentData = try data(for: documentEntry, in: archive)
-		let stylesData = try dataIfAvailable(named: "word/styles.xml", in: archive)
-		let numberingData = try dataIfAvailable(named: "word/numbering.xml", in: archive)
-		let footnotesData = try dataIfAvailable(named: "word/footnotes.xml", in: archive)
+		let stylesData = parts["word/styles.xml"]
+		let numberingData = parts["word/numbering.xml"]
+		let footnotesData = parts["word/footnotes.xml"]
 		return try parseDocumentXML(
 			from: documentData,
 			stylesData: stylesData,
@@ -91,19 +99,6 @@ final class DocxParser {
 			throw DocxFileError.numberingParsingFailed(parser.parserError)
 		}
 		return extractor.catalog
-	}
-
-	private func data(for entry: Entry, in archive: Archive) throws -> Data {
-		var data = Data()
-		_ = try archive.extract(entry) { data.append($0) }
-		return data
-	}
-
-	private func dataIfAvailable(named name: String, in archive: Archive) throws -> Data? {
-		guard let entry = archive[name] else {
-			return nil
-		}
-		return try data(for: entry, in: archive)
 	}
 }
 

--- a/Sources/SwiftTextDOCX/DocxWriter.swift
+++ b/Sources/SwiftTextDOCX/DocxWriter.swift
@@ -1,6 +1,6 @@
 import Foundation
 import SwiftTextCore
-import ZIPFoundation
+import SwiftTextZip
 
 /// Page configuration for DOCX output.
 public struct DocxPageSetup: Sendable {
@@ -185,49 +185,40 @@ public final class DocxWriter {
 		let settingsXML = generateSettings()
 		let fontTableXML = generateFontTable()
 
-		// Create ZIP archive (remove existing file first)
-		let dir = url.deletingLastPathComponent()
-		try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-		if FileManager.default.fileExists(atPath: url.path) {
-			try FileManager.default.removeItem(at: url)
-		}
+		// Assemble the OPC parts, then hand the whole container to libarchive.
+		var entries = [
+			xmlPart("[Content_Types].xml", contentTypes),
+			xmlPart("_rels/.rels", rels),
+			xmlPart("word/_rels/document.xml.rels", documentRels),
+			xmlPart("word/document.xml", documentXML),
+			xmlPart("word/styles.xml", stylesXML),
+			xmlPart("word/numbering.xml", numberingXML),
+			xmlPart("word/settings.xml", settingsXML),
+			xmlPart("word/fontTable.xml", fontTableXML)
+		]
 
-		let archive: Archive
-		do {
-			archive = try Archive(url: url, accessMode: .create)
-		} catch {
-			throw DocxWriterError.archiveCreationFailed
-		}
-
-		try addEntry(archive, path: "[Content_Types].xml", content: contentTypes)
-		try addEntry(archive, path: "_rels/.rels", content: rels)
-		try addEntry(archive, path: "word/_rels/document.xml.rels", content: documentRels)
-		try addEntry(archive, path: "word/document.xml", content: documentXML)
-		try addEntry(archive, path: "word/styles.xml", content: stylesXML)
-		try addEntry(archive, path: "word/numbering.xml", content: numberingXML)
-		try addEntry(archive, path: "word/settings.xml", content: settingsXML)
-		try addEntry(archive, path: "word/fontTable.xml", content: fontTableXML)
-
-		// Embedded image media parts (word/media/imageN.ext).
+		// Embedded image media parts (word/media/imageN.ext). Already-compressed
+		// formats (PNG/JPEG) are stored rather than re-deflated.
 		for media in mediaFiles {
-			try addEntry(archive, path: media.path, data: media.data)
+			entries.append(ZipContainerEntry(path: media.path, data: media.data, stored: true))
 		}
 
 		if !footnotes.isEmpty {
-			try addEntry(archive, path: "word/footnotes.xml", content: generateFootnotes())
+			entries.append(xmlPart("word/footnotes.xml", generateFootnotes()))
+		}
+
+		do {
+			try ZipContainerWriter.write(entries, to: url)
+		} catch {
+			throw DocxWriterError.archiveCreationFailed
 		}
 	}
 
 	// MARK: - Archive Helpers
 
-	private func addEntry(_ archive: Archive, path: String, content: String) throws {
-		try addEntry(archive, path: path, data: Data(content.utf8))
-	}
-
-	private func addEntry(_ archive: Archive, path: String, data: Data) throws {
-		try archive.addEntry(with: path, type: .file, uncompressedSize: Int64(data.count)) { position, size in
-			data[Int(position)..<(Int(position) + size)]
-		}
+	/// An XML part. OPC parts are text, so they always deflate.
+	private func xmlPart(_ path: String, _ content: String) -> ZipContainerEntry {
+		ZipContainerEntry(path: path, data: Data(content.utf8))
 	}
 
 	// MARK: - Body Generation

--- a/Sources/SwiftTextEPUB/EpubArchiveWriter.swift
+++ b/Sources/SwiftTextEPUB/EpubArchiveWriter.swift
@@ -8,7 +8,7 @@
 //  else is deflated, except already-compressed cover images, which are stored.
 
 import Foundation
-import ZIPFoundation
+import SwiftTextZip
 
 /// How a single packaged file is stored in the container.
 enum EpubCompression {
@@ -27,38 +27,21 @@ enum EpubArchiveWriter {
 
 	/// Writes `files` to a new EPUB archive at `url`, in the given order. The
 	/// caller is responsible for placing `mimetype` first with `.stored`
-	/// compression. `modificationDate` stamps every entry so the same input
-	/// yields byte-identical output.
-	static func write(_ files: [EpubFile], to url: URL, modificationDate: Date) throws {
-		let directory = url.deletingLastPathComponent()
-		try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-		if FileManager.default.fileExists(atPath: url.path) {
-			try FileManager.default.removeItem(at: url)
-		}
-
-		let archive = try Archive(url: url, accessMode: .create)
-		for file in files {
-			let method: CompressionMethod = file.compression == .stored ? .none : .deflate
-			let data = file.data
-			try archive.addEntry(
-				with: file.path,
-				type: .file,
-				uncompressedSize: Int64(data.count),
-				modificationDate: modificationDate,
-				compressionMethod: method
-			) { position, size in
-				data.subdata(in: Data.Index(position) ..< Data.Index(position) + size)
-			}
-		}
+	/// compression.
+	static func write(_ files: [EpubFile], to url: URL) throws {
+		try ZipContainerWriter.write(entries(for: files), to: url)
 	}
 
-	/// Builds the archive in a temporary file and returns its bytes. Useful for
-	/// callers (and tests) that want the EPUB as `Data` rather than on disk.
-	static func makeData(_ files: [EpubFile], modificationDate: Date) throws -> Data {
-		let temporary = FileManager.default.temporaryDirectory
-			.appendingPathComponent("swifttext-epub-\(UUID().uuidString).epub")
-		defer { try? FileManager.default.removeItem(at: temporary) }
-		try write(files, to: temporary, modificationDate: modificationDate)
-		return try Data(contentsOf: temporary)
+	/// Builds the archive and returns its bytes. Useful for callers (and tests)
+	/// that want the EPUB as `Data` rather than on disk.
+	static func makeData(_ files: [EpubFile]) throws -> Data {
+		try ZipContainerWriter.makeData(entries(for: files))
+	}
+
+	/// No ZIP entry carries a timestamp, so the same input always yields
+	/// byte-identical output — see ``ZipContainerWriter``. The publication date
+	/// lives in the OPF's `dcterms:modified`, which is the one EPUB readers show.
+	private static func entries(for files: [EpubFile]) -> [ZipContainerEntry] {
+		files.map { ZipContainerEntry(path: $0.path, data: $0.data, stored: $0.compression == .stored) }
 	}
 }

--- a/Sources/SwiftTextEPUB/MarkdownToEpub.swift
+++ b/Sources/SwiftTextEPUB/MarkdownToEpub.swift
@@ -37,13 +37,13 @@ public enum MarkdownToEpub {
 	/// Writes an EPUB for `markdown` to `url`.
 	public static func convert(_ markdown: String, to url: URL, metadata: EpubMetadata, options: EpubOptions = EpubOptions()) throws {
 		let files = makeFiles(markdown, metadata: metadata, options: options)
-		try EpubArchiveWriter.write(files, to: url, modificationDate: metadata.modified)
+		try EpubArchiveWriter.write(files, to: url)
 	}
 
 	/// Builds an EPUB for `markdown` and returns its bytes.
 	public static func makeData(_ markdown: String, metadata: EpubMetadata, options: EpubOptions = EpubOptions()) throws -> Data {
 		let files = makeFiles(markdown, metadata: metadata, options: options)
-		return try EpubArchiveWriter.makeData(files, modificationDate: metadata.modified)
+		return try EpubArchiveWriter.makeData(files)
 	}
 
 	/// Builds the ordered container file list (pre-zip). Exposed internally so

--- a/Sources/SwiftTextIWA/IWAContainer.swift
+++ b/Sources/SwiftTextIWA/IWAContainer.swift
@@ -1,5 +1,5 @@
 import Foundation
-import ZIPFoundation
+import Archive
 
 /// An error reading an iWork document container.
 public enum IWAContainerError: Error, LocalizedError {
@@ -79,12 +79,7 @@ public enum IWAContainer {
 			guard FileManager.default.fileExists(atPath: fileURL.path) else { return nil }
 			return try? Data(contentsOf: fileURL)
 		}
-		guard let archive = try? Archive(url: url, accessMode: .read), let entry = archive[name] else {
-			return nil
-		}
-		var data = Data()
-		guard (try? archive.extract(entry, consumer: { data.append($0) })) != nil else { return nil }
-		return data
+		return try? archiveEntries(at: url) { $0 == name }.first?.data
 	}
 
 	private static func directoryEntries(at url: URL, prefix: String, suffix: String) -> [Entry] {
@@ -105,18 +100,27 @@ public enum IWAContainer {
 	}
 
 	private static func archiveEntries(at url: URL, prefix: String, suffix: String) throws -> [Entry] {
-		let archive: Archive
+		try archiveEntries(at: url) { $0.hasPrefix(prefix) && $0.hasSuffix(suffix) }
+	}
+
+	/// Streams the Zip at `url` once, keeping the regular-file entries whose path
+	/// `isWanted` accepts. libarchive is a sequential reader — there is no random
+	/// access by name — so every lookup is a single pass in stored order.
+	private static func archiveEntries(at url: URL, where isWanted: (String) -> Bool) throws -> [Entry] {
+		let reader: ArchiveReader
 		do {
-			archive = try Archive(url: url, accessMode: .read)
+			reader = try ArchiveReader(path: url.path)
 		} catch {
 			throw IWAContainerError.unreadableArchive(url, error)
 		}
 		var entries = [Entry]()
-		for entry in archive {
-			guard entry.path.hasPrefix(prefix), entry.path.hasSuffix(suffix), !entry.path.hasSuffix("/") else { continue }
-			var data = Data()
-			_ = try archive.extract(entry) { data.append($0) }
-			entries.append(Entry(path: entry.path, data: data))
+		do {
+			try reader.forEachEntry { entry, reader in
+				guard entry.fileType == .regular, isWanted(entry.pathname) else { return }
+				entries.append(Entry(path: entry.pathname, data: try reader.readData()))
+			}
+		} catch {
+			throw IWAContainerError.unreadableArchive(url, error)
 		}
 		return entries
 	}

--- a/Sources/SwiftTextPages/PagesFile.swift
+++ b/Sources/SwiftTextPages/PagesFile.swift
@@ -7,7 +7,7 @@ import Markdown
 ///
 /// Pages files are Zip archives containing an `Index/` folder of iWork Archive
 /// (`.iwa`) objects. Everything needed to read them — Zip access (via
-/// ZIPFoundation), Snappy decompression, and Protocol Buffers decoding — is
+/// libarchive), Snappy decompression, and Protocol Buffers decoding — is
 /// implemented in this module, so no external tooling or Apple frameworks are
 /// required and the same code runs on every platform.
 public final class PagesFile {

--- a/Sources/SwiftTextZip/ZipContainerWriter.swift
+++ b/Sources/SwiftTextZip/ZipContainerWriter.swift
@@ -63,17 +63,23 @@ public enum ZipContainerWriter {
 	/// Writes `entries` to a ZIP archive at `url`, in the given order, replacing
 	/// anything already there.
 	public static func write(_ entries: [ZipContainerEntry], to url: URL) throws {
-		try FileManager.default.createDirectory(
-			at: url.deletingLastPathComponent(),
-			withIntermediateDirectories: true
-		)
-		// Build beside the destination and move into place, so a failure part-way
-		// through can't leave a half-written container behind.
-		let staging = url.deletingLastPathComponent()
-			.appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
-		defer { try? FileManager.default.removeItem(at: staging) }
+		let manager = FileManager.default
+		let directory = url.deletingLastPathComponent()
+		try manager.createDirectory(at: directory, withIntermediateDirectories: true)
+
+		// libarchive streams straight to disk. Build beside the destination and
+		// rename into place, so a failure part-way through can't leave a
+		// half-written container behind — and so the finished archive is never
+		// read back into memory just to be written out again. Staging as a sibling
+		// keeps it on the same volume, making the swap a rename rather than a copy.
+		let staging = directory.appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
+		defer { try? manager.removeItem(at: staging) }
 		try writeArchive(entries, toPath: staging.path)
-		try Data(contentsOf: staging).write(to: url, options: .atomic)
+		if manager.fileExists(atPath: url.path) {
+			_ = try manager.replaceItemAt(url, withItemAt: staging)
+		} else {
+			try manager.moveItem(at: staging, to: url)
+		}
 	}
 
 	/// Builds the archive and returns its bytes, for callers that want the

--- a/Sources/SwiftTextZip/ZipContainerWriter.swift
+++ b/Sources/SwiftTextZip/ZipContainerWriter.swift
@@ -1,0 +1,139 @@
+//  ZipContainerWriter.swift
+//  SwiftTextZip
+//
+//  Writes the ZIP containers SwiftText produces — `.docx` (OPC) and `.epub`
+//  (OCF) — with libarchive.
+//
+//  This drives the raw `archive_*` C API rather than swift-archive's
+//  `ArchiveWriter`, for one reason: `ArchiveEntry.apply()` always calls
+//  `archive_entry_set_uid/gid/mtime`, and libarchive emits a `ux` extra block
+//  when uid/gid are set and a `UT` extra block when any timestamp is. Entries
+//  here set none of the three, which no public API on `ArchiveWriter` can
+//  currently express, and which buys two things:
+//
+//  * **A bare `mimetype` header.** EPUB's OCF container forbids *any* extra
+//    field on that entry — the rule that puts `application/epub+zip` at the
+//    fixed offset 38 reading systems sniff.
+//  * **Reproducible output.** libarchive derives the MS-DOS timestamp with
+//    `localtime()`, so a stamped archive would differ byte-for-byte between two
+//    machines in different timezones, and the `UT` extra block would then carry
+//    a machine-dependent value too. Unstamped entries date to the 1980 ZIP epoch
+//    everywhere. Container formats keep their real dates in their own metadata
+//    (`dcterms:modified` in an EPUB's OPF, `docProps` in an OPC package), which
+//    is what readers surface anyway.
+//
+//  libarchive always writes streaming entries (general-purpose bit 3 set, sizes
+//  and CRC in a trailing data descriptor) — `ZIP_ENTRY_FLAG_LENGTH_AT_END` is
+//  unconditional, because it never knows the CRC when the local header goes out.
+//  That is conformant for both formats: epubcheck accepts it, and so do OPC
+//  readers. Formats that need the sizes *in* the local header — iWork's stored
+//  `.pages` layout, which must reproduce Apple's bytes exactly — use
+//  `StoredZipWriter` in SwiftTextPages instead.
+
+import Foundation
+import Archive
+
+/// A regular file destined for a ZIP container.
+public struct ZipContainerEntry: Sendable {
+	/// Path inside the archive, e.g. `word/document.xml`.
+	public let path: String
+	public let data: Data
+	/// When `false`, the entry is DEFLATEd (ZIP method 8).
+	public let stored: Bool
+
+	public init(path: String, data: Data, stored: Bool = false) {
+		self.path = path
+		self.data = data
+		self.stored = stored
+	}
+}
+
+public enum ZipContainerWriterError: Error, LocalizedError {
+	case writeFailed(String)
+
+	public var errorDescription: String? {
+		switch self {
+		case .writeFailed(let message): return "Could not write the ZIP container: \(message)"
+		}
+	}
+}
+
+public enum ZipContainerWriter {
+
+	/// Writes `entries` to a ZIP archive at `url`, in the given order, replacing
+	/// anything already there.
+	public static func write(_ entries: [ZipContainerEntry], to url: URL) throws {
+		try FileManager.default.createDirectory(
+			at: url.deletingLastPathComponent(),
+			withIntermediateDirectories: true
+		)
+		// Build beside the destination and move into place, so a failure part-way
+		// through can't leave a half-written container behind.
+		let staging = url.deletingLastPathComponent()
+			.appendingPathComponent(".\(url.lastPathComponent).\(UUID().uuidString).tmp")
+		defer { try? FileManager.default.removeItem(at: staging) }
+		try writeArchive(entries, toPath: staging.path)
+		try Data(contentsOf: staging).write(to: url, options: .atomic)
+	}
+
+	/// Builds the archive and returns its bytes, for callers that want the
+	/// container in memory rather than on disk.
+	public static func makeData(_ entries: [ZipContainerEntry]) throws -> Data {
+		let staging = FileManager.default.temporaryDirectory
+			.appendingPathComponent("swifttext-zip-\(UUID().uuidString)")
+		defer { try? FileManager.default.removeItem(at: staging) }
+		try writeArchive(entries, toPath: staging.path)
+		return try Data(contentsOf: staging)
+	}
+
+	private static func writeArchive(_ entries: [ZipContainerEntry], toPath path: String) throws {
+		guard let archive = archive_write_new() else {
+			throw ZipContainerWriterError.writeFailed("could not create a libarchive writer")
+		}
+		defer { archive_write_free(archive) }
+
+		try check(archive_write_set_format_zip(archive), archive)
+		try check(archive_write_open_filename(archive, path), archive)
+
+		for entry in entries {
+			try check(
+				entry.stored
+					? archive_write_zip_set_compression_store(archive)
+					: archive_write_zip_set_compression_deflate(archive),
+				archive
+			)
+			guard let header = archive_entry_new() else {
+				throw ZipContainerWriterError.writeFailed("could not create a libarchive entry")
+			}
+			defer { archive_entry_free(header) }
+			archive_entry_set_pathname(header, entry.path)
+			archive_entry_set_filetype(header, Self.regularFile)
+			archive_entry_set_size(header, Int64(entry.data.count))
+			// uid/gid/mtime are deliberately never set — see the file comment.
+			try check(archive_write_header(archive, header), archive)
+
+			if !entry.data.isEmpty {
+				let written = entry.data.withUnsafeBytes { buffer in
+					archive_write_data(archive, buffer.baseAddress, buffer.count)
+				}
+				guard written == entry.data.count else {
+					throw ZipContainerWriterError.writeFailed(errorMessage(archive))
+				}
+			}
+		}
+
+		try check(archive_write_close(archive), archive)
+	}
+
+	/// `AE_IFREG` — the macro uses a C cast Swift can't import.
+	private static let regularFile: UInt32 = 0o100000
+
+	private static func check(_ status: Int32, _ archive: OpaquePointer) throws {
+		guard status != ARCHIVE_OK && status != ARCHIVE_WARN else { return }
+		throw ZipContainerWriterError.writeFailed(errorMessage(archive))
+	}
+
+	private static func errorMessage(_ archive: OpaquePointer) -> String {
+		archive_error_string(archive).map { String(cString: $0) } ?? "unknown libarchive error"
+	}
+}

--- a/Tests/SwiftTextDOCXTests/DocxArchiveTestSupport.swift
+++ b/Tests/SwiftTextDOCXTests/DocxArchiveTestSupport.swift
@@ -1,0 +1,52 @@
+//  DocxArchiveTestSupport.swift
+//  SwiftTextDOCXTests
+//
+//  Reads a written `.docx` back so tests can assert on its parts. libarchive is
+//  a sequential reader with no lookup by name, so the container is slurped once
+//  and indexed here — which also keeps the stored order available for tests that
+//  care about it.
+
+import Foundation
+import Archive
+
+struct DocxArchive {
+	/// Regular-file entry paths, in the order they are stored.
+	let paths: [String]
+	private let parts: [String: Data]
+
+	init(contentsOf url: URL) throws {
+		let reader = try ArchiveReader(path: url.path)
+		var paths = [String]()
+		var parts = [String: Data]()
+		try reader.forEachEntry { entry, reader in
+			guard entry.fileType == .regular else { return }
+			paths.append(entry.pathname)
+			parts[entry.pathname] = try reader.readData()
+		}
+		self.paths = paths
+		self.parts = parts
+	}
+
+	func data(_ path: String) throws -> Data {
+		guard let data = parts[path] else { throw DocxArchiveError.missingPart(path) }
+		return data
+	}
+
+	func text(_ path: String) throws -> String {
+		String(decoding: try data(path), as: UTF8.self)
+	}
+
+	func contains(_ path: String) -> Bool {
+		parts[path] != nil
+	}
+}
+
+enum DocxArchiveError: Error, CustomStringConvertible {
+	case missingPart(String)
+
+	var description: String {
+		switch self {
+		case .missingPart(let path): return "missing part \(path)"
+		}
+	}
+}

--- a/Tests/SwiftTextDOCXTests/DocxFootnoteTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxFootnoteTests.swift
@@ -1,6 +1,6 @@
 import Foundation
+import SwiftTextZip
 import Testing
-import ZIPFoundation
 
 @testable import SwiftTextDOCX
 
@@ -44,9 +44,6 @@ struct DocxFootnoteTests {
 
 	/// Builds a minimal `.docx` Zip from the given part paths/contents.
 	private func makeDocx(parts: [String: String]) throws -> URL {
-		let build = FileManager.default.temporaryDirectory
-			.appendingPathComponent("docx-build-\(UUID().uuidString)", isDirectory: true)
-		defer { try? FileManager.default.removeItem(at: build) }
 		let contentTypes = """
 		<?xml version="1.0" encoding="UTF-8"?>
 		<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">\
@@ -56,14 +53,11 @@ struct DocxFootnoteTests {
 		"""
 		var all = parts
 		all["[Content_Types].xml"] = contentTypes
-		for (path, contents) in all {
-			let fileURL = build.appendingPathComponent(path)
-			try FileManager.default.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-			try Data(contents.utf8).write(to: fileURL)
-		}
+		let entries = all.sorted(by: { $0.key < $1.key })
+			.map { ZipContainerEntry(path: $0.key, data: Data($0.value.utf8)) }
 		let url = FileManager.default.temporaryDirectory
 			.appendingPathComponent("footnotes-\(UUID().uuidString).docx")
-		try FileManager.default.zipItem(at: build, to: url, shouldKeepParent: false, compressionMethod: .deflate)
+		try ZipContainerWriter.write(entries, to: url)
 		return url
 	}
 }

--- a/Tests/SwiftTextDOCXTests/DocxFootnoteWriterTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxFootnoteWriterTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftTextDOCX
 import Testing
-import ZIPFoundation
 
 @Suite("DOCX footnote writer")
 struct DocxFootnoteWriterTests {
@@ -20,13 +19,10 @@ struct DocxFootnoteWriterTests {
 
 		try MarkdownToDocx.convert(markdown, to: url)
 
-		let archive = try #require(Archive(url: url, accessMode: .read))
+		let archive = try DocxArchive(contentsOf: url)
 
 		func part(_ path: String) throws -> String {
-			let entry = try #require(archive[path], "missing part \(path)")
-			var data = Data()
-			_ = try archive.extract(entry) { data.append($0) }
-			return String(decoding: data, as: UTF8.self)
+			try archive.text(path)
 		}
 
 		// The footnotes part exists and holds the note body plus the required
@@ -94,13 +90,9 @@ struct DocxFootnoteWriterTests {
 
 		try MarkdownToDocx.convert("Just a plain paragraph.", to: url)
 
-		let archive = try #require(Archive(url: url, accessMode: .read))
-		#expect(archive["word/footnotes.xml"] == nil)
-
-		var data = Data()
-		let entry = try #require(archive["[Content_Types].xml"])
-		_ = try archive.extract(entry) { data.append($0) }
-		#expect(!String(decoding: data, as: UTF8.self).contains("footnotes"))
+		let archive = try DocxArchive(contentsOf: url)
+		#expect(!archive.contains("word/footnotes.xml"))
+		#expect(!(try archive.text("[Content_Types].xml").contains("footnotes")))
 	}
 
 	@Test("A footnote reference inside a table header cell is rendered, not dropped")
@@ -119,7 +111,7 @@ struct DocxFootnoteWriterTests {
 
 		try MarkdownToDocx.convert(markdown, to: url)
 
-		let archive = try #require(Archive(url: url, accessMode: .read))
+		let archive = try DocxArchive(contentsOf: url)
 		// The only reference is in the header cell, so its presence proves the
 		// header path renders footnote runs (it now goes through renderRuns).
 		#expect(try part("word/document.xml", from: archive).contains("<w:footnoteReference w:id=\"1\"/>"))
@@ -140,18 +132,15 @@ struct DocxFootnoteWriterTests {
 		defer { try? FileManager.default.removeItem(at: url) }
 		try writer.write(to: url)
 
-		let archive = try #require(Archive(url: url, accessMode: .read))
-		#expect(archive["word/footnotes.xml"] == nil)
+		let archive = try DocxArchive(contentsOf: url)
+		#expect(!archive.contains("word/footnotes.xml"))
 		let document = try part("word/document.xml", from: archive)
 		#expect(!document.contains("<w:footnoteReference"))
 		#expect(document.contains("[^1]"))  // reference stays literal
 	}
 
 	/// Reads a part out of a `.docx` archive as a UTF-8 string.
-	private func part(_ path: String, from archive: Archive) throws -> String {
-		let entry = try #require(archive[path], "missing part \(path)")
-		var data = Data()
-		_ = try archive.extract(entry) { data.append($0) }
-		return String(decoding: data, as: UTF8.self)
+	private func part(_ path: String, from archive: DocxArchive) throws -> String {
+		try archive.text(path)
 	}
 }

--- a/Tests/SwiftTextDOCXTests/DocxImageTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxImageTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftTextDOCX
 import Testing
-import ZIPFoundation
 
 @Suite("DOCX Images")
 struct DocxImageTests {
@@ -17,15 +16,6 @@ struct DocxImageTests {
 		return dir
 	}
 
-	private static func text(of path: String, in archive: Archive) throws -> String {
-		guard let entry = archive[path] else {
-			throw DocxImageTestError.missingEntry(path)
-		}
-		var data = Data()
-		_ = try archive.extract(entry) { data.append($0) }
-		return String(decoding: data, as: UTF8.self)
-	}
-
 	@Test("Embeds a referenced PNG as an inline image")
 	func embedsReferencedPNG() throws {
 		let dir = try Self.makeTempDir()
@@ -38,18 +28,15 @@ struct DocxImageTests {
 		let docxURL = dir.appendingPathComponent("out.docx")
 		try MarkdownToDocx.convert(markdown, to: docxURL, baseURL: dir)
 
-		let archive = try #require(Archive(url: docxURL, accessMode: .read))
+		let archive = try DocxArchive(contentsOf: docxURL)
 
 		// A media part for the embedded image exists, byte-identical to the source.
-		let mediaPaths = archive.map(\.path).filter { $0.hasPrefix("word/media/") }
+		let mediaPaths = archive.paths.filter { $0.hasPrefix("word/media/") }
 		#expect(mediaPaths.count == 1)
-		let mediaEntry = try #require(archive[mediaPaths[0]])
-		var mediaData = Data()
-		_ = try archive.extract(mediaEntry) { mediaData.append($0) }
-		#expect(mediaData == pngData)
+		#expect(try archive.data(mediaPaths[0]) == pngData)
 
 		// document.xml carries the inline drawing referencing the embedded blip.
-		let document = try Self.text(of: "word/document.xml", in: archive)
+		let document = try archive.text("word/document.xml")
 		#expect(document.contains("<w:drawing>"))
 		#expect(document.contains("<a:blip r:embed="))
 		#expect(document.contains("<pic:pic>"))
@@ -58,10 +45,10 @@ struct DocxImageTests {
 		#expect(document.contains("cy=\"9525\""))
 
 		// Content type + relationship are wired up.
-		let contentTypes = try Self.text(of: "[Content_Types].xml", in: archive)
+		let contentTypes = try archive.text("[Content_Types].xml")
 		#expect(contentTypes.contains("<Default Extension=\"png\" ContentType=\"image/png\"/>"))
 
-		let rels = try Self.text(of: "word/_rels/document.xml.rels", in: archive)
+		let rels = try archive.text("word/_rels/document.xml.rels")
 		#expect(rels.contains("/relationships/image"))
 		#expect(rels.contains("Target=\"media/image1.png\""))
 	}
@@ -75,10 +62,10 @@ struct DocxImageTests {
 		let docxURL = dir.appendingPathComponent("out.docx")
 		try MarkdownToDocx.convert(markdown, to: docxURL, baseURL: dir)
 
-		let archive = try #require(Archive(url: docxURL, accessMode: .read))
-		#expect(!archive.map(\.path).contains { $0.hasPrefix("word/media/") })
+		let archive = try DocxArchive(contentsOf: docxURL)
+		#expect(!archive.paths.contains { $0.hasPrefix("word/media/") })
 
-		let document = try Self.text(of: "word/document.xml", in: archive)
+		let document = try archive.text("word/document.xml")
 		#expect(!document.contains("<w:drawing>"))
 		#expect(document.contains("banner alt"))
 		#expect(document.contains("<w:i/>")) // italic placeholder
@@ -93,13 +80,9 @@ struct DocxImageTests {
 		let docxURL = dir.appendingPathComponent("out.docx")
 		try MarkdownToDocx.convert(markdown, to: docxURL) // no baseURL
 
-		let archive = try #require(Archive(url: docxURL, accessMode: .read))
-		#expect(!archive.map(\.path).contains { $0.hasPrefix("word/media/") })
-		let document = try Self.text(of: "word/document.xml", in: archive)
+		let archive = try DocxArchive(contentsOf: docxURL)
+		#expect(!archive.paths.contains { $0.hasPrefix("word/media/") })
+		let document = try archive.text("word/document.xml")
 		#expect(document.contains("just text"))
 	}
-}
-
-private enum DocxImageTestError: Error {
-	case missingEntry(String)
 }

--- a/Tests/SwiftTextDOCXTests/DocxStrikethroughTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxStrikethroughTests.swift
@@ -1,6 +1,6 @@
 import Foundation
+import SwiftTextZip
 import Testing
-import ZIPFoundation
 
 @testable import SwiftTextDOCX
 
@@ -25,12 +25,6 @@ struct DocxStrikethroughTests {
 	/// Builds a minimal `.docx` (a Zip with `[Content_Types].xml` and the given
 	/// `word/document.xml`).
 	private func makeDocx(documentXML: String) throws -> URL {
-		let build = FileManager.default.temporaryDirectory
-			.appendingPathComponent("docx-build-\(UUID().uuidString)", isDirectory: true)
-		let wordDir = build.appendingPathComponent("word", isDirectory: true)
-		try FileManager.default.createDirectory(at: wordDir, withIntermediateDirectories: true)
-		defer { try? FileManager.default.removeItem(at: build) }
-
 		let contentTypes = """
 		<?xml version="1.0" encoding="UTF-8"?>
 		<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">\
@@ -38,12 +32,12 @@ struct DocxStrikethroughTests {
 		<Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>\
 		</Types>
 		"""
-		try Data(contentTypes.utf8).write(to: build.appendingPathComponent("[Content_Types].xml"))
-		try Data(documentXML.utf8).write(to: wordDir.appendingPathComponent("document.xml"))
-
 		let url = FileManager.default.temporaryDirectory
 			.appendingPathComponent("strike-\(UUID().uuidString).docx")
-		try FileManager.default.zipItem(at: build, to: url, shouldKeepParent: false, compressionMethod: .deflate)
+		try ZipContainerWriter.write([
+			ZipContainerEntry(path: "[Content_Types].xml", data: Data(contentTypes.utf8)),
+			ZipContainerEntry(path: "word/document.xml", data: Data(documentXML.utf8))
+		], to: url)
 		return url
 	}
 }

--- a/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
+++ b/Tests/SwiftTextDOCXTests/DocxWriterTests.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftTextDOCX
 import Testing
-import ZIPFoundation
 
 @Suite("DOCX Writer")
 struct DocxWriterTests {
@@ -30,18 +29,15 @@ struct DocxWriterTests {
 		try writer.write(to: url)
 
 		// Verify it's a valid ZIP with the expected OOXML parts
-		let archive = try #require(Archive(url: url, accessMode: .read))
-		let paths = archive.map(\.path)
+		let archive = try DocxArchive(contentsOf: url)
+		let paths = archive.paths
 		#expect(paths.contains("[Content_Types].xml"))
 		#expect(paths.contains("word/document.xml"))
 		#expect(paths.contains("word/styles.xml"))
 		#expect(paths.contains("word/numbering.xml"))
 
 		// Extract document.xml and verify content
-		var documentData = Data()
-		let entry = try #require(archive["word/document.xml"])
-		_ = try archive.extract(entry) { documentData.append($0) }
-		let xml = String(data: documentData, encoding: .utf8)!
+		let xml = try archive.text("word/document.xml")
 		#expect(xml.contains("Test Heading"))
 		#expect(xml.contains("<w:b/>"))
 		#expect(xml.contains("<w:i/>"))
@@ -78,11 +74,8 @@ struct DocxWriterTests {
 
 		try MarkdownToDocx.convert(markdown, to: url)
 
-		let archive = try #require(Archive(url: url, accessMode: .read))
-		var documentData = Data()
-		let entry = try #require(archive["word/document.xml"])
-		_ = try archive.extract(entry) { documentData.append($0) }
-		let xml = String(data: documentData, encoding: .utf8)!
+		let archive = try DocxArchive(contentsOf: url)
+		let xml = try archive.text("word/document.xml")
 
 		#expect(xml.contains("Hello World"))
 		#expect(xml.contains("Heading1"))
@@ -118,11 +111,8 @@ struct DocxWriterTests {
 
 		try MarkdownToDocx.convert(markdown, to: url)
 
-		let archive = try #require(Archive(url: url, accessMode: .read))
-		var documentData = Data()
-		let entry = try #require(archive["word/document.xml"])
-		_ = try archive.extract(entry) { documentData.append($0) }
-		let xml = String(data: documentData, encoding: .utf8)!
+		let archive = try DocxArchive(contentsOf: url)
+		let xml = try archive.text("word/document.xml")
 
 		#expect(xml.components(separatedBy: #"<w:numId w:val="1"/>"#).count - 1 == 2)
 		#expect(xml.components(separatedBy: #"<w:numId w:val="2"/>"#).count - 1 == 2)
@@ -142,11 +132,8 @@ struct DocxWriterTests {
 
 		try MarkdownToDocx.convert(markdown, to: url)
 
-		let archive = try #require(Archive(url: url, accessMode: .read))
-		var documentData = Data()
-		let entry = try #require(archive["word/document.xml"])
-		_ = try archive.extract(entry) { documentData.append($0) }
-		let xml = String(data: documentData, encoding: .utf8)!
+		let archive = try DocxArchive(contentsOf: url)
+		let xml = try archive.text("word/document.xml")
 
 		#expect(xml.contains("Old"))
 		#expect(xml.contains("<w:strike/>"))

--- a/Tests/SwiftTextEPUBTests/EpubTests.swift
+++ b/Tests/SwiftTextEPUBTests/EpubTests.swift
@@ -35,7 +35,13 @@ struct EpubTests {
 		let extraLen = Int(UInt16(bytes[28]) | UInt16(bytes[29]) << 8)
 		let name = String(decoding: bytes[30 ..< 30 + nameLen], as: UTF8.self)
 		#expect(name == "mimetype")
+		// OCF: "there MUST NOT be an extra field" on the mimetype entry, which is
+		// what puts the media type at the fixed offset 38 that readers sniff.
+		// libarchive emits a `UT` extra block for any entry carrying a timestamp,
+		// so the writer stamps every entry *except* this one — hence the assertion.
+		#expect(extraLen == 0)
 		let payloadStart = 30 + nameLen + extraLen
+		#expect(payloadStart == 38)
 		let payload = String(decoding: bytes[payloadStart ..< payloadStart + 20], as: UTF8.self)
 		#expect(payload == "application/epub+zip")
 	}
@@ -205,5 +211,44 @@ struct EpubTests {
 		let a = try MarkdownToEpub.makeData(markdown, metadata: metadata, options: EpubOptions())
 		let b = try MarkdownToEpub.makeData(markdown, metadata: metadata, options: EpubOptions())
 		#expect(a == b)
+	}
+
+	@Test("no entry carries a timestamp, so output can't vary by machine timezone")
+	func noEntryTimestamps() throws {
+		// Comparing two runs in one process can't catch timezone dependence, so
+		// assert it structurally: libarchive derives the MS-DOS timestamp with
+		// `localtime()` and adds a `UT` extra block whenever an entry has an mtime.
+		// Unstamped entries show the 1980 ZIP epoch and no extra field anywhere.
+		let bytes = [UInt8](try MarkdownToEpub.makeData("# One\n\naa", metadata: fixedMetadata(), options: EpubOptions()))
+		func u16(_ offset: Int) -> Int { Int(bytes[offset]) | Int(bytes[offset + 1]) << 8 }
+		func u32(_ offset: Int) -> Int {
+			Int(bytes[offset]) | Int(bytes[offset + 1]) << 8
+				| Int(bytes[offset + 2]) << 16 | Int(bytes[offset + 3]) << 24
+		}
+
+		// Entries are streamed (sizes live in a trailing data descriptor), so the
+		// local section can't be walked forwards — go through the central directory,
+		// which is authoritative and points at each local header.
+		let eocd = bytes.count - 22
+		#expect(u32(eocd) == 0x0605_4b50)
+		let count = u16(eocd + 10)
+		#expect(count > 1)
+
+		var position = u32(eocd + 16)
+		for _ in 0 ..< count {
+			#expect(u32(position) == 0x0201_4b50)
+			let nameLength = u16(position + 28)
+			let name = String(decoding: bytes[position + 46 ..< position + 46 + nameLength], as: UTF8.self)
+			#expect(u16(position + 12) == 0, "\(name): central header has a DOS time")
+			#expect(u16(position + 14) == 0x21, "\(name): central header is not dated 1980-01-01")
+			#expect(u16(position + 30) == 0, "\(name): central header has an extra field")
+
+			let local = u32(position + 42)
+			#expect(u16(local + 10) == 0, "\(name): local header has a DOS time")
+			#expect(u16(local + 12) == 0x21, "\(name): local header is not dated 1980-01-01")
+			#expect(u16(local + 28) == 0, "\(name): local header has an extra field")
+
+			position += 46 + nameLength + u16(position + 30) + u16(position + 32)
+		}
 	}
 }


### PR DESCRIPTION
Closes #46 (the Zip-container half; the PDF-deflate options in that issue are untouched).

## Why

`Package.swift` pinned ZIPFoundation to an untagged `development` HEAD — the only commit carrying the Windows `#import` → `#include` fix ([weichsel/ZIPFoundation#380](https://github.com/weichsel/ZIPFoundation/pull/380)), without which the DOCX/Pages readers can't build on Windows. Upstream still hasn't tagged a release with it. This swaps in [marcprux/swift-archive](https://github.com/marcprux/swift-archive) 3.8.9, which vendors libarchive as C sources behind a thin Swift wrapper, so there's no system libarchive to provision and we're back on a version tag.

`GzipSupport` is enabled explicitly — it's **off by default upstream**, and without zlib libarchive can't inflate DEFLATE entries, i.e. every real `.docx`/`.epub`.

## What changed

**Reading** — DOCX parts, DOCX media, the iWork `.iwa` container — goes through `ArchiveReader`. libarchive is a sequential reader with no lookup by name, so each call streams the container once and keeps the entries it wants rather than seeking per part.

**Writing** `.docx` and `.epub` goes through the new `SwiftTextZip` target, which drives the raw `archive_*` C API rather than `ArchiveWriter`. `ArchiveEntry.apply()` unconditionally sets uid/gid/mtime, and libarchive emits a `ux` extra block for uid/gid and a `UT` block for any timestamp. Setting none of the three buys two things no public `ArchiveWriter` API can express:

- **A bare `mimetype` header.** EPUB's OCF container forbids *any* extra field on that entry — the rule that keeps `application/epub+zip` at the fixed offset 38 reading systems sniff.
- **Reproducible output.** libarchive derives the MS-DOS timestamp with `localtime()`, where ZIPFoundation used `gmtime()`. Stamping would make archives differ byte-for-byte between machines in different timezones, and pre-compensating the mtime would just move that machine-dependence into the `UT` field. Entries now date to the 1980 ZIP epoch everywhere; the real date still lives in the OPF's `dcterms:modified`, which is what readers surface. `.docx` gains this too — it was previously stamped with ZIPFoundation's `Date()` default and was never reproducible.

**iWork writing stays on the hand-rolled `StoredZipWriter`.** `.pages` needs stored entries with sizes and CRC *in* the local header plus Apple's exact per-entry metadata; libarchive always writes streaming entries with a trailing data descriptor (`ZIP_ENTRY_FLAG_LENGTH_AT_END` is unconditional — it never knows the CRC when the local header goes out). That file is untouched by this PR.

Output got ~9% **smaller**: real zlib compresses better than anything hand-rolled.

## Reviewer notes

⚠️ **Breaking: the platform floor rises to macOS 13 / iOS 15 / tvOS 15 / watchOS 10** (from macOS 12 / iOS 13 / tvOS 13 / watchOS 6). SwiftPM requires a package to be at least as new as any product it links, and swift-archive's own floor is macOS 13 / iOS 15. `platforms:` is package-wide, so the pure-Swift targets inherit it even though they don't link libarchive. README's Requirements section now states this explicitly.

**The doubled product entry in `SwiftTextZip` is deliberate:**

```swift
.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["DOCX"])),
.product(name: "Archive", package: "swift-archive", condition: .when(traits: ["EPUB"]))
```

The target is shared by two independently-gated modules, and Swift 6.2's SwiftPM requires *all* traits in one `.when(traits:)` to be enabled (6.3 changed this to any-of). Spelling OR as separate dependencies keeps 6.2 working. Verified this doesn't leak: a consumer with `traits: ["HTML"]` still resolves only swift-markdown/cmark/XMLKit, so the README's lean-resolution claim holds.

**Known and accepted:** libarchive's zip reader has `#ifdef DEBUG` tracing, and SwiftPM passes `-DDEBUG=1` to C targets in debug builds, so a handful of `Header id 0x…` lines go to stderr per archive that carries extra fields (Apple's `.pages` do; our own output doesn't). Release builds are silent, stdout is unaffected, and text output is byte-identical either way. Fixing it needs a one-line `#undef DEBUG` in swift-archive's `config_spm.h` — can't be done downstream, since `cSettings` don't apply to a dependency's target.

**CI:** Linux now installs `zlib1g-dev` + `libssl-dev` (libarchive links `-lz` and `-lcrypto` there). Windows already provisioned vcpkg zlib as `z.lib`, which is exactly what `CArchive`'s `.linkedLibrary("z")` wants, so that job needed only comment updates.

## Verification

- 496 tests pass; SwiftLint `--strict` clean; iOS `xcodebuild` succeeds; portable subset (`SWIFTTEXT_PORTABLE_ONLY=1`) builds and runs its 153 tests
- **epubcheck: 0 fatals / 0 errors / 0 warnings** on generated EPUBs; `mimetype` stored, `extraLen` 0, media type at offset 38
- Python `zipfile.testzip()` (CRC-checks every entry) passes on generated `.docx` and `.epub`
- `textutil` — Apple's own OOXML reader — parses the generated `.docx`
- `.docx` byte-identical under `TZ=UTC` vs `TZ=Pacific/Auckland`; EPUB entry headers likewise. New test walks the central directory asserting no timestamps and no extra fields, so this can't silently regress
- Real-world `.pages` and `.docx` read correctly through the release CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)