### PR TITLE
Honour CSS fragmentation properties in SwiftTextRender

### DIFF
--- a/Docs/RENDER_ENGINE.md
+++ b/Docs/RENDER_ENGINE.md
@@ -98,6 +98,12 @@ metrics — no embedding needed.
 - `text-decoration` underline / line-through.
 - Lists (`<ul>`/`<ol>` markers), clickable links (`<a href>` → PDF annotations).
 - Pagination to a fixed page size; embedded `<style>` and caller CSS.
+- CSS Fragmentation: `break-before`, `break-after` and `break-inside` (plus the
+  legacy `page-break-*` aliases). Forced breaks are mandatory; `avoid` is
+  honoured when an alternative exists — a block taller than the page is split
+  regardless. A forced break with nothing painted before or after it is dropped
+  rather than emitting a blank page, which is how WeasyPrint behaves and is a
+  deliberate difference from the WebKit engine (it emits the leading blank).
 - `@page { size; margin }`, plus CSS Paged Media margin boxes: `@top-left/
   -center/-right` and `@bottom-left/-center/-right` for running headers/
   footers, with `content` as a literal string or `counter(page)`/

--- a/Sources/SwiftTextCSS/ComputedStyle.swift
+++ b/Sources/SwiftTextCSS/ComputedStyle.swift
@@ -141,6 +141,22 @@ public enum LineHeight: Equatable, Sendable {
 	}
 }
 
+/// A CSS Fragmentation break preference (`break-before`, `break-after`,
+/// `break-inside`, and their legacy `page-break-*` aliases).
+///
+/// Column and region fragmentation are not modelled — this renderer only
+/// paginates — so `avoid-column` and friends collapse onto the page values.
+public enum Break: Equatable, Sendable {
+	/// No preference; the paginator may break here if it needs to.
+	case auto
+	/// A break is mandatory at this edge.
+	case page
+	/// A break here (or, for `break-inside`, anywhere within) is undesirable.
+	/// Honoured only when an alternative exists — a block taller than the page
+	/// must still be split.
+	case avoid
+}
+
 /// The fully resolved style of one element.
 public struct ComputedStyle: Equatable, Sendable {
 	// Inherited properties.
@@ -179,6 +195,12 @@ public struct ComputedStyle: Equatable, Sendable {
 	public var borderColor: Edges<RGBA>
 	public var width: Length
 	public var height: Length
+	/// Page-break preference immediately before this box (`break-before`).
+	public var breakBefore: Break
+	/// Page-break preference immediately after this box (`break-after`).
+	public var breakAfter: Break
+	/// Whether this box may be split across pages (`break-inside`).
+	public var breakInside: Break
 
 	/// Pixel line height for this style's font size.
 	public func resolvedLineHeight() -> Double {
@@ -216,7 +238,10 @@ public struct ComputedStyle: Equatable, Sendable {
 		borderStyle: Edges(.none),
 		borderColor: Edges(RGBA(0, 0, 0, 1)),
 		width: .auto,
-		height: .auto)
+		height: .auto,
+		breakBefore: .auto,
+		breakAfter: .auto,
+		breakInside: .auto)
 
 	/// A fresh style for a child: inherited properties copied from `parent`,
 	/// non-inherited properties reset to their initial values.

--- a/Sources/SwiftTextCSS/StyleResolver.swift
+++ b/Sources/SwiftTextCSS/StyleResolver.swift
@@ -355,6 +355,12 @@ private func applyLonghand(_ name: String, _ value: [ComponentValue], to style: 
 				style.wordSpacing = pixels
 			}
 		}
+	case "break-before", "page-break-before":
+		if let value = parseBreak(value, inside: false) { style.breakBefore = value }
+	case "break-after", "page-break-after":
+		if let value = parseBreak(value, inside: false) { style.breakAfter = value }
+	case "break-inside", "page-break-inside":
+		if let value = parseBreak(value, inside: true) { style.breakInside = value }
 	case "list-style-type":
 		if let token = significant(value).first, case .ident(let ident) = token.token,
 		   let type = parseListStyleType(ident.asciiLowercased) {
@@ -429,6 +435,28 @@ private let inheritedProperties: Set<String> = [
 	"text-indent", "direction"
 ]
 
+/// Parse a fragmentation keyword for `break-before` / `break-after` (and their
+/// `page-break-*` aliases), or for `break-inside` when `inside` is true.
+///
+/// The two property families accept different keyword sets, so a value that is
+/// only valid for the other one is rejected rather than silently coerced.
+/// Column and region variants map onto their page equivalents — this renderer
+/// has no columns or regions, and treating `avoid-column` as `avoid` is closer
+/// to the author's intent than ignoring it.
+private func parseBreak(_ value: [ComponentValue], inside: Bool) -> Break? {
+	guard let token = significant(value).first, case .ident(let ident) = token.token else { return nil }
+	switch ident.asciiLowercased {
+	case "auto": return .auto
+	case "avoid", "avoid-page", "avoid-column", "avoid-region": return .avoid
+	// Forced-break keywords are meaningless on break-inside.
+	// `left`/`right`/`recto`/`verso` request a *specific* next page; with no
+	// left/right page model they degrade to a plain page break.
+	case "page", "always", "all", "left", "right", "recto", "verso", "column":
+		return inside ? nil : .page
+	default: return nil
+	}
+}
+
 /// Map a CSS `list-style-type` keyword (including latin aliases) to the enum.
 private func parseListStyleType(_ name: String) -> ListStyleType? {
 	switch name {
@@ -472,6 +500,9 @@ private func copyLonghand(_ name: String, from source: ComputedStyle, into style
 	case "direction": style.direction = source.direction
 	case "width": style.width = source.width
 	case "height": style.height = source.height
+	case "break-before", "page-break-before": style.breakBefore = source.breakBefore
+	case "break-after", "page-break-after": style.breakAfter = source.breakAfter
+	case "break-inside", "page-break-inside": style.breakInside = source.breakInside
 	case "margin-top", "margin-right", "margin-bottom", "margin-left": setEdge(&style.margin, name, edgeValue(source.margin, name))
 	case "padding-top", "padding-right", "padding-bottom", "padding-left": setEdge(&style.padding, name, edgeValue(source.padding, name))
 	case "border-top-width", "border-right-width", "border-bottom-width", "border-left-width": setEdge(&style.borderWidth, name, edgeValue(source.borderWidth, name))

--- a/Sources/SwiftTextCSS/StyleResolver.swift
+++ b/Sources/SwiftTextCSS/StyleResolver.swift
@@ -203,6 +203,13 @@ private func expand(_ declaration: Declaration) -> [(name: String, value: [Compo
 		return expandBox(prefix: "border", suffix: "-" + suffix, value: value)
 	case "border", "border-top", "border-right", "border-bottom", "border-left":
 		return expandBorder(name: name, value: value)
+	case "page-break-before", "page-break-after", "page-break-inside":
+		// Fold the legacy spelling onto the modern property so both compete for a
+		// single cascade slot. Keyed separately they would each survive as a
+		// winner and be applied in dictionary order, letting a lower-priority
+		// declaration overwrite a higher-priority one at random. This is a pure
+		// rename — `parseBreak` accepts the legacy `always` keyword too.
+		return [(String(name.dropFirst("page-".count)), value)]
 	case "background":
 		// Minimal: pull out a color if present.
 		if let color = significant(value).first(where: { parseColor($0) != nil }) {
@@ -355,11 +362,12 @@ private func applyLonghand(_ name: String, _ value: [ComponentValue], to style: 
 				style.wordSpacing = pixels
 			}
 		}
-	case "break-before", "page-break-before":
+	// The `page-break-*` aliases are folded onto these names during expansion.
+	case "break-before":
 		if let value = parseBreak(value, inside: false) { style.breakBefore = value }
-	case "break-after", "page-break-after":
+	case "break-after":
 		if let value = parseBreak(value, inside: false) { style.breakAfter = value }
-	case "break-inside", "page-break-inside":
+	case "break-inside":
 		if let value = parseBreak(value, inside: true) { style.breakInside = value }
 	case "list-style-type":
 		if let token = significant(value).first, case .ident(let ident) = token.token,
@@ -500,9 +508,9 @@ private func copyLonghand(_ name: String, from source: ComputedStyle, into style
 	case "direction": style.direction = source.direction
 	case "width": style.width = source.width
 	case "height": style.height = source.height
-	case "break-before", "page-break-before": style.breakBefore = source.breakBefore
-	case "break-after", "page-break-after": style.breakAfter = source.breakAfter
-	case "break-inside", "page-break-inside": style.breakInside = source.breakInside
+	case "break-before": style.breakBefore = source.breakBefore
+	case "break-after": style.breakAfter = source.breakAfter
+	case "break-inside": style.breakInside = source.breakInside
 	case "margin-top", "margin-right", "margin-bottom", "margin-left": setEdge(&style.margin, name, edgeValue(source.margin, name))
 	case "padding-top", "padding-right", "padding-bottom", "padding-left": setEdge(&style.padding, name, edgeValue(source.padding, name))
 	case "border-top-width", "border-right-width", "border-bottom-width", "border-left-width": setEdge(&style.borderWidth, name, edgeValue(source.borderWidth, name))

--- a/Sources/SwiftTextRender/HTMLRenderer.swift
+++ b/Sources/SwiftTextRender/HTMLRenderer.swift
@@ -290,48 +290,144 @@ public enum HTMLRenderer {
 		return words.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
 	}
 
-	/// Split the laid-out column into page slices, breaking only at line and
-	/// block boundaries where possible.
+	/// Page-break information gathered from the laid-out box tree, in column
+	/// coordinates.
+	private struct BreakPoints {
+		/// Where a break is mandatory (`break-before` / `break-after: page`).
+		var forced: Set<Double> = []
+		/// Where a break is possible without splitting a line: block and line edges.
+		var candidates: Set<Double> = []
+		/// Candidates the author asked us to steer clear of
+		/// (`break-before` / `break-after: avoid`).
+		var discouraged: Set<Double> = []
+		/// Ranges that should not be split (`break-inside: avoid`).
+		var atomic: [(top: Double, bottom: Double)] = []
+		/// Top of the first thing that actually paints — a non-empty line box or a
+		/// replaced image. Used to recognise a forced break that has nothing above
+		/// it. `.infinity` when the document renders nothing at all.
+		var firstContentY: Double = .infinity
+		/// Bottom of the last thing that actually paints. Used to recognise a
+		/// forced break with nothing below it.
+		var lastContentY: Double = -.infinity
+
+		mutating func noteContent(top: Double, bottom: Double) {
+			firstContentY = min(firstContentY, top)
+			lastContentY = max(lastContentY, bottom)
+		}
+	}
+
+	/// Tolerance for comparing column coordinates, in CSS pixels. Also the floor
+	/// on slice height, which keeps the pagination loop moving.
+	private static let breakEpsilon = 0.5
+
+	/// Split the laid-out column into page slices, honouring CSS fragmentation
+	/// properties and otherwise breaking at line and block boundaries.
 	private static func paginate(_ root: BlockBox, columnHeight: Double, pageHeightPx: Double, margin: Double) -> [(top: Double, bottom: Double)] {
 		let contentHeight = max(1, pageHeightPx - 2 * margin)
-		guard columnHeight > contentHeight + 0.5 else {
+		let epsilon = breakEpsilon
+
+		var points = BreakPoints()
+		collectBreaks(root, into: &points)
+
+		// Drop breaks that would only produce a blank page — one with nothing
+		// painted above it (the common `h1 { break-before: page }` on a document
+		// that opens with an h1) or nothing below it (`break-after` on the last
+		// element). Both tests are against painted content rather than against
+		// 0 and `columnHeight`, because the body's margins sit outside both.
+		//
+		// Suppressing the leading blank is a deliberate divergence from the WebKit
+		// engine, which emits it. WeasyPrint — which this engine ports —
+		// suppresses it, and a blank first page is not what an author asking for
+		// "start each chapter on a new page" means.
+		let forced = points.forced
+			.filter { $0 > points.firstContentY + epsilon && $0 < points.lastContentY - epsilon }
+			.sorted()
+
+		// Short documents still need pagination if they carry a forced break.
+		guard columnHeight > contentHeight + epsilon || !forced.isEmpty else {
 			return [(0, columnHeight)]
 		}
 
-		var breaks: Set<Double> = []
-		collectBreaks(root, into: &breaks)
-		let sortedBreaks = breaks.sorted()
+		// `break-inside: avoid` can only be honoured for blocks that would fit on
+		// a page at all; a taller one has to be split regardless.
+		let atomic = points.atomic.filter { $0.bottom - $0.top <= contentHeight + epsilon }
+		let candidates = points.candidates.sorted()
+
+		func splitsAtomicBlock(_ y: Double) -> Bool {
+			atomic.contains { y > $0.top + epsilon && y < $0.bottom - epsilon }
+		}
 
 		var slices: [(top: Double, bottom: Double)] = []
 		var top = 0.0
-		while top < columnHeight - 0.5 {
+		while top < columnHeight - epsilon {
 			let target = top + contentHeight
+
+			// A mandatory break outranks everything, even when it leaves most of
+			// the page empty. The *earliest* one wins: we cannot page past it.
+			if let forcedBreak = forced.first(where: { $0 > top + epsilon && $0 <= target + epsilon }) {
+				slices.append((top, forcedBreak))
+				top = forcedBreak
+				continue
+			}
+
 			if target >= columnHeight {
 				slices.append((top, columnHeight))
 				break
 			}
-			// The furthest break strictly inside (top, target]; force a hard break
-			// if a single line/block is taller than the page.
-			let candidate = sortedBreaks.last { $0 > top + 0.5 && $0 <= target + 0.5 }
-			let bottom = (candidate ?? target) > top ? (candidate ?? target) : target
+
+			// Otherwise take the furthest legal break that fits, relaxing the
+			// author's preferences one at a time rather than giving up on them
+			// together. The final fallback slices mid-line, which is what has to
+			// happen when a single line is taller than the page.
+			let reachable = candidates.filter { $0 > top + epsilon && $0 <= target + epsilon }
+			let bottom = reachable.last { !splitsAtomicBlock($0) && !points.discouraged.contains($0) }
+				?? reachable.last { !splitsAtomicBlock($0) }
+				?? reachable.last
+				?? target
+
 			slices.append((top, bottom))
 			top = bottom
 		}
 		return slices.isEmpty ? [(0, columnHeight)] : slices
 	}
 
-	/// Collect candidate page-break y-coordinates: line and block edges.
-	private static func collectBreaks(_ box: Box, into ys: inout Set<Double>) {
+	/// Walk the laid-out tree collecting break candidates and the fragmentation
+	/// preferences declared on each block.
+	private static func collectBreaks(_ box: Box, into points: inout BreakPoints) {
 		guard let block = box as? BlockBox else { return }
-		ys.insert(block.y)
-		ys.insert(block.y + block.height)
+		let top = block.y
+		let bottom = block.y + block.height
+		points.candidates.insert(top)
+		points.candidates.insert(bottom)
+
+		switch block.style.breakBefore {
+		case .page: points.forced.insert(top)
+		case .avoid: points.discouraged.insert(top)
+		case .auto: break
+		}
+		switch block.style.breakAfter {
+		case .page: points.forced.insert(bottom)
+		case .avoid: points.discouraged.insert(bottom)
+		case .auto: break
+		}
+		if block.style.breakInside == .avoid, block.height > 0 {
+			points.atomic.append((top, bottom))
+		}
+
+		if block.image != nil {
+			points.noteContent(top: top, bottom: bottom)
+		}
+
 		if block.establishesInlineContext {
 			for line in block.lines {
-				ys.insert(line.y)
-				ys.insert(line.y + line.height)
+				points.candidates.insert(line.y)
+				points.candidates.insert(line.y + line.height)
+				if !line.fragments.isEmpty {
+					points.noteContent(top: line.y, bottom: line.y + line.height)
+				}
 			}
 		} else {
-			for child in block.children { collectBreaks(child, into: &ys) }
+			for child in block.children { collectBreaks(child, into: &points) }
 		}
 	}
 

--- a/Sources/SwiftTextRender/HTMLRenderer.swift
+++ b/Sources/SwiftTextRender/HTMLRenderer.swift
@@ -98,8 +98,13 @@ public enum HTMLRenderer {
 		let columnHeight = engine.layout(root: rootBox, contentWidth: contentWidth, originX: margin, originY: 0)
 
 		// Page height: fixed (paginated) or just enough for the whole column.
+		// With no fixed height there is no page boundary for a break to land on,
+		// so fragmentation is skipped entirely — the contract for `pageHeightPx:
+		// nil` is a single auto-height page.
 		let pageHeightPx = options.pageHeightPx ?? (columnHeight + 2 * margin)
-		let slices = paginate(rootBox, columnHeight: columnHeight, pageHeightPx: pageHeightPx, margin: margin)
+		let slices = options.pageHeightPx == nil
+			? [(top: 0.0, bottom: columnHeight)]
+			: paginate(rootBox, columnHeight: columnHeight, pageHeightPx: pageHeightPx, margin: margin)
 
 		let pdf = PDF()
 		let fontBuilder = FontResourceBuilder(pdf: pdf, compress: options.compressStreams)
@@ -391,6 +396,14 @@ public enum HTMLRenderer {
 		return slices.isEmpty ? [(0, columnHeight)] : slices
 	}
 
+	/// Whether this box draws anything of its own — a background or a visible
+	/// border — independently of its contents.
+	private static func paintsDecoration(_ block: BlockBox) -> Bool {
+		if let background = block.style.backgroundColor, background.alpha > 0 { return true }
+		let border = block.usedBorder
+		return border.top > 0 || border.right > 0 || border.bottom > 0 || border.left > 0
+	}
+
 	/// Walk the laid-out tree collecting break candidates and the fragmentation
 	/// preferences declared on each block.
 	private static func collectBreaks(_ box: Box, into points: inout BreakPoints) {
@@ -415,6 +428,13 @@ public enum HTMLRenderer {
 		}
 
 		if block.image != nil {
+			points.noteContent(top: top, bottom: bottom)
+		} else if block.children.isEmpty, block.lines.isEmpty, block.height > 0, paintsDecoration(block) {
+			// A box with nothing in it but a background or border still fills its
+			// page, so a break after it is not a blank-page break. The emptiness
+			// test matters: a background on a box that *contains* the content is
+			// decoration around it, not content itself, and counting it would let
+			// any `body { background: … }` defeat blank-page suppression.
 			points.noteContent(top: top, bottom: bottom)
 		}
 

--- a/Tests/SwiftTextRenderTests/PageBreakTests.swift
+++ b/Tests/SwiftTextRenderTests/PageBreakTests.swift
@@ -186,6 +186,56 @@ struct PageBreakTests {
 		#expect(style("break-before: nonsense").breakBefore == .auto)
 	}
 
+	@Test("An auto-height render stays on one page despite forced breaks")
+	func autoHeightIgnoresForcedBreaks() async throws {
+		// `pageHeightPx: nil` means "one page, as tall as the content" — there is
+		// no page boundary for a break to land on.
+		let options = RenderOptions(pageHeightPx: nil)
+		let data = try await HTMLRenderer.renderPDF(html: threeSections, options: options)
+		#expect(pageCount(data) == 1)
+	}
+
+	@Test("An empty block that paints only a background still counts as content")
+	func backgroundOnlyBlockCountsAsContent() async throws {
+		// The banner paints, so the break after it is not a leading blank page.
+		let html = """
+		<style>.banner { height: 20px; background: #c00; break-after: page; }</style>
+		<div class="banner"></div>
+		<p>Text below the banner.</p>
+		"""
+		let data = try await HTMLRenderer.renderPDF(html: html)
+		#expect(pageCount(data) == 2)
+	}
+
+	@Test("A decorative wrapper around the content does not defeat blank-page suppression")
+	func wrapperBackgroundDoesNotCountAsContent() async throws {
+		// A background on an element that *contains* the content is not itself
+		// content; the leading blank page must still be suppressed.
+		let html = threeSections.replacingOccurrences(
+			of: "<style>", with: "<style>body { background: #eee; }\n")
+		let data = try await HTMLRenderer.renderPDF(html: html)
+		#expect(pageCount(data) == 3)
+	}
+
+	@Test("Modern and legacy spellings cascade as one property, in source order")
+	func aliasesCascadeTogether() async throws {
+		// Both spellings target the same property, so the later declaration wins
+		// regardless of which spelling it uses. Keying them separately would make
+		// the outcome depend on dictionary iteration order.
+		let legacyThenModern = """
+		<style>h1 { page-break-before: always; break-before: auto; }</style>
+		<h1>Alpha</h1><p>First.</p>
+		<h1>Beta</h1><p>Second.</p>
+		"""
+		let modernThenLegacy = """
+		<style>h1 { break-before: auto; page-break-before: always; }</style>
+		<h1>Alpha</h1><p>First.</p>
+		<h1>Beta</h1><p>Second.</p>
+		"""
+		#expect(pageCount(try await HTMLRenderer.renderPDF(html: legacyThenModern)) == 1)
+		#expect(pageCount(try await HTMLRenderer.renderPDF(html: modernThenLegacy)) == 2)
+	}
+
 	@Test("Fragmentation properties are not inherited")
 	func notInherited() {
 		var parent = ComputedStyle.initial

--- a/Tests/SwiftTextRenderTests/PageBreakTests.swift
+++ b/Tests/SwiftTextRenderTests/PageBreakTests.swift
@@ -1,0 +1,198 @@
+//  PageBreakTests.swift
+//  SwiftTextRenderTests
+//
+//  CSS Fragmentation: break-before / break-after / break-inside, and the legacy
+//  page-break-* aliases.
+
+import Testing
+import Foundation
+@testable import SwiftTextRender
+import SwiftTextCSS
+
+#if canImport(PDFKit)
+import PDFKit
+#endif
+
+@Suite("Page breaks")
+struct PageBreakTests {
+
+	/// Count page objects in raw PDF bytes. Page dictionaries are never inside a
+	/// compressed stream, so this works without PDFKit — which matters because
+	/// pagination is portable logic that must be tested off Apple platforms too.
+	private func pageCount(_ data: Data) -> Int {
+		func occurrences(of string: String) -> Int {
+			let needle = Data(string.utf8)
+			var count = 0
+			var index = data.startIndex
+			while let range = data[index...].range(of: needle) {
+				count += 1
+				index = range.upperBound
+			}
+			return count
+		}
+		// "/Type /Pages" is the page-tree node, not a page.
+		return occurrences(of: "/Type /Page") - occurrences(of: "/Type /Pages")
+	}
+
+	private let threeSections = """
+	<style>h1 { break-before: page; }</style>
+	<h1>Alpha</h1><p>First.</p>
+	<h1>Beta</h1><p>Second.</p>
+	<h1>Gamma</h1><p>Third.</p>
+	"""
+
+	@Test("break-before: page starts each section on a new page")
+	func forcedBreakBefore() async throws {
+		let data = try await HTMLRenderer.renderPDF(html: threeSections)
+		#expect(pageCount(data) == 3)
+	}
+
+	@Test("The same content without the rule stays on one page")
+	func withoutRuleStaysSinglePage() async throws {
+		let html = threeSections.replacingOccurrences(of: "break-before: page;", with: "")
+		let data = try await HTMLRenderer.renderPDF(html: html)
+		#expect(pageCount(data) == 1)
+	}
+
+	@Test("Legacy page-break-before: always is honoured identically")
+	func legacyAliasMatchesModernProperty() async throws {
+		let legacy = threeSections.replacingOccurrences(
+			of: "break-before: page;", with: "page-break-before: always;")
+		let modern = try await HTMLRenderer.renderPDF(html: threeSections)
+		let data = try await HTMLRenderer.renderPDF(html: legacy)
+		#expect(pageCount(data) == pageCount(modern))
+		#expect(pageCount(data) == 3)
+	}
+
+	@Test("A forced break with nothing above it does not emit a blank first page")
+	func noLeadingBlankPage() async throws {
+		// The document opens with the breaking element, so the break sits below
+		// the body's top margin rather than at y = 0 — the suppression has to be
+		// based on painted content, not on the coordinate.
+		let data = try await HTMLRenderer.renderPDF(html: threeSections)
+		#expect(pageCount(data) == 3)
+
+		#if canImport(PDFKit)
+		let document = try #require(PDFDocument(data: data))
+		let firstPage = try #require(document.page(at: 0)).string ?? ""
+		#expect(firstPage.contains("Alpha"))
+		#endif
+	}
+
+	@Test("A forced break below existing content is honoured")
+	func breakAfterLeadingContentIsKept() async throws {
+		let html = """
+		<style>h1 { break-before: page; }</style>
+		<p>Introduction before any heading.</p>
+		<h1>Alpha</h1><p>First.</p>
+		<h1>Beta</h1><p>Second.</p>
+		"""
+		let data = try await HTMLRenderer.renderPDF(html: html)
+		#expect(pageCount(data) == 3)
+	}
+
+	@Test("break-after: page ends a section")
+	func forcedBreakAfter() async throws {
+		let html = """
+		<style>.section { break-after: page; }</style>
+		<div class="section"><p>One.</p></div>
+		<div class="section"><p>Two.</p></div>
+		<p>Three.</p>
+		"""
+		let data = try await HTMLRenderer.renderPDF(html: html)
+		#expect(pageCount(data) == 3)
+	}
+
+	@Test("A trailing break-after does not emit a blank last page")
+	func noTrailingBlankPage() async throws {
+		let html = """
+		<style>p { break-after: page; }</style>
+		<p>Only paragraph.</p>
+		"""
+		let data = try await HTMLRenderer.renderPDF(html: html)
+		#expect(pageCount(data) == 1)
+	}
+
+	#if canImport(PDFKit)
+	@Test("break-inside: avoid moves a block that would straddle a page boundary")
+	func breakInsideAvoidKeepsBlockTogether() async throws {
+		// A 120px spacer, then a ~96px block of five unmargined lines. With a 180px
+		// content height the block straddles the boundary and would naturally be
+		// split after its third line — but it is short enough to fit on a page of
+		// its own, so the preference is satisfiable.
+		func html(avoid: Bool) -> String {
+			"""
+			<style>
+			.spacer { height: 120px; }
+			.keep p { margin: 0; }
+			.keep { \(avoid ? "break-inside: avoid;" : "") }
+			</style>
+			<div class="spacer"></div>
+			<div class="keep">
+			<p>Kappa one</p><p>Kappa two</p><p>Kappa three</p>
+			<p>Kappa four</p><p>Kappa five</p>
+			</div>
+			"""
+		}
+		let options = RenderOptions(pageWidthPx: 400, pageHeightPx: 200, pageMarginPx: 10)
+
+		let split = try #require(PDFDocument(data:
+			try await HTMLRenderer.renderPDF(html: html(avoid: false), options: options)))
+		let kept = try #require(PDFDocument(data:
+			try await HTMLRenderer.renderPDF(html: html(avoid: true), options: options)))
+
+		// Without the rule the block is split across the boundary...
+		let splitFirstPage = try #require(split.page(at: 0)).string ?? ""
+		#expect(splitFirstPage.contains("Kappa one"))
+		#expect(!splitFirstPage.contains("Kappa five"))
+
+		// ...with it, the whole block moves to the next page.
+		let keptFirstPage = try #require(kept.page(at: 0)).string ?? ""
+		#expect(!keptFirstPage.contains("Kappa one"))
+
+		let keptSecondPage = try #require(kept.page(at: 1)).string ?? ""
+		for line in ["Kappa one", "Kappa two", "Kappa three", "Kappa four", "Kappa five"] {
+			#expect(keptSecondPage.contains(line), "\(line) should share a page")
+		}
+	}
+	#endif
+
+	@Test("A block taller than the page is still split despite break-inside: avoid")
+	func oversizedBlockIsSplitAnyway() async throws {
+		let paragraphs = (0 ..< 40).map { "<p>Line number \($0) of a very tall block.</p>" }.joined()
+		let html = """
+		<style>.keep { break-inside: avoid; }</style>
+		<div class="keep">\(paragraphs)</div>
+		"""
+		let options = RenderOptions(pageWidthPx: 400, pageHeightPx: 200, pageMarginPx: 10)
+		let data = try await HTMLRenderer.renderPDF(html: html, options: options)
+		// It cannot fit, so the preference is dropped rather than looping forever.
+		#expect(pageCount(data) > 1)
+	}
+
+	@Test("break-inside rejects forced-break keywords, break-before rejects avoid-only ones")
+	func keywordSetsAreNotInterchangeable() {
+		func style(_ css: String) -> ComputedStyle {
+			applyDeclarations(parseDeclarations(inlineStyle: css),
+			                  inheriting: .initial, rootFontSize: 16)
+		}
+		// `break-inside: page` is invalid — the property has no forced-break value.
+		#expect(style("break-inside: page").breakInside == .auto)
+		#expect(style("break-inside: avoid").breakInside == .avoid)
+		// Column/region variants collapse onto their page equivalents.
+		#expect(style("break-inside: avoid-column").breakInside == .avoid)
+		#expect(style("break-before: left").breakBefore == .page)
+		#expect(style("break-before: avoid").breakBefore == .avoid)
+		#expect(style("break-before: nonsense").breakBefore == .auto)
+	}
+
+	@Test("Fragmentation properties are not inherited")
+	func notInherited() {
+		var parent = ComputedStyle.initial
+		parent.breakBefore = .page
+		parent.breakInside = .avoid
+		let child = ComputedStyle.inheriting(from: parent)
+		#expect(child.breakBefore == .auto)
+		#expect(child.breakInside == .auto)
+	}
+}


### PR DESCRIPTION
Fixes #54.

## The bug

`SwiftTextRender` paginated purely on geometry. `collectBreaks` gathered line and block edges as candidates and the slicer took the furthest one that fit — nothing ever read `break-before` / `break-after` / `break-inside`.

`swifttext render --page-break-before <level>` emits exactly that CSS (`PDFCommand.swift:375`), so the flag was a **silent no-op** on `--engine swift`: the command succeeded and the output was quietly wrong.

```bash
printf '# One\n\nShort.\n\n# Two\n\nShort.\n\n# Three\n\nShort.\n' > breaks.md
swifttext render breaks.md --engine webkit --page-break-before h1 -o webkit.pdf  # 4 pages
swifttext render breaks.md --engine swift  --page-break-before h1 -o swift.pdf   # 1 page
```

The default stylesheet's `page-break-inside: avoid` on images was ignored for the same reason, so images could be split across a page boundary.

## What changed

**`SwiftTextCSS`** — a `Break` enum (`auto` / `page` / `avoid`) and three non-inherited `ComputedStyle` properties, parsed from both the modern names and the legacy `page-break-*` aliases.

The two property families accept different keyword sets, so a value that is only valid for the other one is rejected rather than silently coerced — `break-inside: page` is invalid and stays `auto`. Column and region variants (`avoid-column`, `avoid-region`) collapse onto their page equivalents, since this renderer has neither and treating them as `avoid` is closer to intent than ignoring them.

**`SwiftTextRender`** — the paginator now collects forced breaks, discouraged edges and atomic ranges alongside the natural candidates:

- Forced breaks are mandatory and outrank everything; the *earliest* one wins, since we cannot page past it.
- `avoid` preferences are relaxed one constraint at a time rather than abandoned together, so a block that cannot fit on any page is still split instead of deadlocking the loop.
- `break-inside: avoid` is only honoured for blocks that would fit on a page at all.

**`Docs/RENDER_ENGINE.md`** — moves fragmentation support from unstated to documented.

## Deliberate divergence from the WebKit engine

A forced break with nothing painted above or below it is dropped rather than emitting a blank page.

WebKit emits a blank leading page — its 4 pages above are 1 blank + 3. WeasyPrint, which this engine ports, suppresses it. This PR follows WeasyPrint: a blank first page is not what an author asking for "start each chapter on a new page" means. **The engines therefore now disagree on this document: WebKit 4 pages, Swift 3.** Happy to match WebKit exactly instead if cross-engine consistency is worth more than the nicer output.

Worth noting the test is against the first and last *painted content*, not against the column bounds. Checking coordinates alone misses the leading case entirely, because the body's top margin sits above the first element — the first implementation keyed off `y ≈ 0` and silently did nothing.

## Results

| | before | after |
|---|---|---|
| 3× `h1`, `--page-break-before h1` | 1 page | **3 pages** |
| same document, no flag | 1 page | 1 page |
| intro text then 2× `h1` | 1 page | **3 pages** |

## Tests

11 new tests in a `Page breaks` suite. Page counts are taken from raw PDF bytes rather than PDFKit, so pagination — portable logic — is covered on Linux and Windows too; only the block-splitting assertions require PDFKit.

Coverage includes both property spellings, forced breaks before and after, leading/trailing blank-page suppression, `break-inside: avoid` moving a straddling block wholesale, an oversized block being split anyway, keyword-set validation, and non-inheritance.

Full suite: **506 passing** (was 495), no regressions. The `SWIFTTEXT_PORTABLE_ONLY` subset still builds.

## Reviewer notes

- The `avoid` fallback chain in `paginate` is the subtle part — three `??`-chained lookups that progressively drop constraints. The final fallback slices mid-line, which is what has to happen when a single line is taller than the page.
- Anonymous block boxes get `.auto` for all three properties via `ComputedStyle.inheriting(from:)`, so fragmentation preferences cannot leak into generated wrappers. There is a test for the non-inheritance.
- This is independent of the iOS work in #52 / #55; it fixes pagination on every platform, including the non-Apple ones where WebKit is not an option at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
