### PR TITLE
Make WebKitBrowser's load path fail instead of hanging

### DIFF
--- a/Sources/SwiftTextHTML/WebKitBrowser.swift
+++ b/Sources/SwiftTextHTML/WebKitBrowser.swift
@@ -10,14 +10,38 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 	public let url: URL
 
 	// MARK: - Internal Properties
+	private static let messageName = "pageLoaded"
+
 	private var webView: WKWebView!
 	private var htmlResult: String?
 	private var didLoad = false
-	private var continuation: CheckedContinuation<String?, Never>?
-	private var loadContinuation: CheckedContinuation<Void, Never>?
+	/// Whether the load reached a terminal state — captured, failed, or timed out.
+	/// Distinct from ``didLoad``, which means the HTML was actually captured.
+	private var isFinished = false
+	/// Every awaiting `waitForLoadCompletion()` call. A single stored continuation
+	/// would be overwritten by a second caller, stranding the first forever.
+	private var loadContinuations: [CheckedContinuation<Void, Never>] = []
+	private var timeoutTask: Task<Void, Never>?
+	private var messageProxy: ScriptMessageProxy?
 	private var htmlStringToLoad: String?
 	private var fileURLToLoad: URL?
 	private var readAccessRoot: URL?
+
+	/// Why the load ended without capturing HTML, or `nil` if it succeeded.
+	/// Set before ``waitForLoadCompletion()`` returns, and rethrown by the export
+	/// methods.
+	public private(set) var loadError: Error?
+
+	/// How long to wait for the page to settle before giving up, in seconds.
+	/// Set to `0` to wait indefinitely.
+	///
+	/// This backstop is what makes the class safe to use in a long-lived app.
+	/// The 3 s cap inside the injected script is a JS `setTimeout`, so it only
+	/// fires if the page got far enough to *run* that script — it does nothing
+	/// for a navigation that fails outright, or for a web content process that
+	/// is suspended or killed (which is what happens when an iOS app is
+	/// backgrounded) before the script is ever injected.
+	public var timeout: TimeInterval = 30
 
 	/// Optional frame size override. When set, the WKWebView is created
 	/// with this size so content reflows to the target width (e.g. A4).
@@ -61,25 +85,40 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 		super.init()
 	}
 
+	/// Waits until the page has settled, failed, or timed out.
+	///
+	/// Always returns — see ``timeout``. Inspect ``loadError`` to tell a capture
+	/// from a failure; the export methods do that for you.
 	@MainActor
 	public func waitForLoadCompletion() async {
-		guard !didLoad else {
+		guard !isFinished else {
 			return
 		}
 
 		await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-			loadContinuation = continuation
-			self.load()
+			loadContinuations.append(continuation)
+			// Only the first caller starts the load; later ones just queue up.
+			if loadContinuations.count == 1 {
+				self.load()
+			}
 		}
+	}
+
+	/// Waits for the load and rethrows whatever ended it badly, so an export
+	/// never silently operates on a blank page.
+	@MainActor
+	private func loadedWebView() async throws -> WKWebView {
+		await waitForLoadCompletion()
+		if let loadError {
+			throw loadError
+		}
+		return webView
 	}
 
 	@MainActor
 	@available(macOS 12.0, *)
 	public func exportPDF(to outputURL: URL) async throws {
-		if !didLoad {
-			await waitForLoadCompletion()
-		}
-
+		let webView = try await loadedWebView()
 		let data = try await webView.pdf()
 		try data.write(to: outputURL)
 	}
@@ -91,10 +130,7 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 	@MainActor
 	@available(macOS 12.0, *)
 	public func exportPDFData(configuration: WKPDFConfiguration = WKPDFConfiguration()) async throws -> Data {
-		if !didLoad {
-			await waitForLoadCompletion()
-		}
-
+		let webView = try await loadedWebView()
 		return try await webView.pdf(configuration: configuration)
 	}
 
@@ -109,9 +145,7 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 	@MainActor
 	@available(macOS 11.0, *)
 	public func exportPaginatedPDFData(paperSize: CGSize) async throws -> Data {
-		if !didLoad {
-			await waitForLoadCompletion()
-		}
+		let webView = try await loadedWebView()
 
 		let tempURL = FileManager.default.temporaryDirectory
 			.appendingPathComponent(UUID().uuidString)
@@ -151,8 +185,19 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 	private func load() {
 		let config = WKWebViewConfiguration()
 		let contentController = WKUserContentController()
-		contentController.add(self, name: "pageLoaded")
+		// Register a weak proxy rather than `self`. A user-content controller
+		// retains its message handlers, and this object owns the web view that
+		// owns the configuration that owns the controller — handing it `self`
+		// closes that loop, so the browser (and its web content process) is never
+		// released. Harmless in a CLI that exits; an app doing repeated loads
+		// leaks a process per instance.
+		let proxy = ScriptMessageProxy()
+		proxy.target = self
+		messageProxy = proxy
+		contentController.add(proxy, name: Self.messageName)
 		config.userContentController = contentController
+
+		startTimeoutIfNeeded()
 
 		let initialSize = frameSize ?? CGSize(width: 800, height: 600)
 		webView = WKWebView(frame: CGRect(origin: .zero, size: initialSize), configuration: config)
@@ -165,6 +210,44 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 		} else {
 			let urlRequest = URLRequest(url: url)
 			webView.load(urlRequest)
+		}
+	}
+
+	/// Arms the Swift-side backstop that guarantees `waitForLoadCompletion()`
+	/// returns even if WebKit never calls back at all.
+	@MainActor
+	private func startTimeoutIfNeeded() {
+		guard timeout > 0 else { return }
+		let seconds = timeout
+		timeoutTask = Task { @MainActor [weak self] in
+			try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+			guard let self, !Task.isCancelled else { return }
+			self.finish(error: WebKitBrowserError.timedOut(seconds: seconds))
+		}
+	}
+
+	/// The single exit point for a load. Idempotent: whichever of capture,
+	/// navigation failure, process termination, or timeout happens first wins,
+	/// and the rest become no-ops.
+	@MainActor
+	private func finish(error: Error?) {
+		guard !isFinished else { return }
+		isFinished = true
+		loadError = error
+
+		timeoutTask?.cancel()
+		timeoutTask = nil
+
+		// Drop the message handler as soon as the page is captured: it is the one
+		// strong reference WebKit holds on our behalf, and nothing more arrives.
+		webView?.configuration.userContentController.removeScriptMessageHandler(forName: Self.messageName)
+		messageProxy?.target = nil
+		messageProxy = nil
+
+		let waiting = loadContinuations
+		loadContinuations.removeAll()
+		for continuation in waiting {
+			continuation.resume()
 		}
 	}
 
@@ -208,46 +291,65 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 			}
 		}
 	}
+
+	/// A navigation that started and then failed. Without this the injected
+	/// script never runs, so nothing would ever resume the waiters.
+	public func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+		finish(error: WebKitBrowserError.loadFailed(underlying: error))
+	}
+
+	/// A navigation that never started — bad host, no network, refused
+	/// connection. The common failure, and the one that used to hang forever.
+	public func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+		finish(error: WebKitBrowserError.loadFailed(underlying: error))
+	}
+
+	/// The web content process died — out-of-memory, a crash, or the system
+	/// reclaiming it (which is what a backgrounded iOS app's process gets). The
+	/// page is gone and no further callback is coming.
+	public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+		finish(error: WebKitBrowserError.webContentProcessTerminated)
+	}
+}
+
+/// Registered with the user-content controller in place of the browser itself,
+/// so WebKit's strong reference to its message handler cannot close a cycle
+/// back onto the browser. See the comment in `load()`.
+@available(macOS 10.15, *)
+private final class ScriptMessageProxy: NSObject, WKScriptMessageHandler {
+	weak var target: WebKitBrowser?
+
+	func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+		target?.userContentController(userContentController, didReceive: message)
+	}
 }
 
 @available(macOS 10.15, *)
 extension WebKitBrowser: WKScriptMessageHandler {
 	@objc public func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-		guard message.name == "pageLoaded", let html = message.body as? String else {
+		guard message.name == Self.messageName, let html = message.body as? String else {
+			return
+		}
+		guard !isFinished else {
 			return
 		}
 
 		didLoad = true
 		htmlResult = html
 
-		Task {
-			do {
-				if !preserveFrameHeight {
-					let maxSize = try await webView.getMaxScrollSize()
-					self.updateWebView(size: maxSize)
-				}
-
-				self.loadContinuation?.resume()
-				self.loadContinuation = nil
-
-			} catch {
-				self.loadContinuation?.resume()
-				self.loadContinuation = nil
+		Task { @MainActor in
+			// A failed resize is not a failed load — we already have the HTML.
+			if !self.preserveFrameHeight, let maxSize = try? await self.webView.getMaxScrollSize() {
+				self.updateWebView(size: maxSize)
 			}
+			self.finish(error: nil)
 		}
-
-		continuation?.resume(returning: html)
-		continuation = nil
 	}
 }
 
 @available(macOS 10.15, *)
 extension WebKitBrowser {
 	public func html() async -> String? {
-		if didLoad {
-			return htmlResult
-		}
-
 		await waitForLoadCompletion()
 		return htmlResult
 	}
@@ -316,9 +418,30 @@ extension WKWebView {
 	}
 }
 
-public enum WebKitBrowserError: Error {
+public enum WebKitBrowserError: Error, LocalizedError {
 	case missingHTML
 	case printFailed
+	/// WebKit reported a navigation failure; `underlying` is its error.
+	case loadFailed(underlying: Error)
+	/// The page never settled within ``WebKitBrowser/timeout``.
+	case timedOut(seconds: TimeInterval)
+	/// The web content process died before the page could be captured.
+	case webContentProcessTerminated
+
+	public var errorDescription: String? {
+		switch self {
+		case .missingHTML:
+			return "The page produced no HTML"
+		case .printFailed:
+			return "The print operation did not produce a PDF"
+		case .loadFailed(let underlying):
+			return "The page failed to load: \(underlying.localizedDescription)"
+		case .timedOut(let seconds):
+			return "The page did not finish loading within \(Int(seconds)) seconds"
+		case .webContentProcessTerminated:
+			return "The web content process terminated before the page was captured"
+		}
+	}
 }
 
 // MARK: - Print Operation Helper

--- a/Sources/SwiftTextHTML/WebKitBrowser.swift
+++ b/Sources/SwiftTextHTML/WebKitBrowser.swift
@@ -104,14 +104,20 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 		}
 	}
 
-	/// Waits for the load and rethrows whatever ended it badly, so an export
-	/// never silently operates on a blank page.
+	/// Waits for the load and rethrows whatever ended it badly, so no export
+	/// silently operates on a blank page — or reports a vague "no HTML" when the
+	/// real cause was a refused connection or a timeout.
 	@MainActor
-	private func loadedWebView() async throws -> WKWebView {
+	private func ensureLoaded() async throws {
 		await waitForLoadCompletion()
 		if let loadError {
 			throw loadError
 		}
+	}
+
+	@MainActor
+	private func loadedWebView() async throws -> WKWebView {
+		try await ensureLoaded()
 		return webView
 	}
 
@@ -174,7 +180,8 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 
 	@MainActor
 	public func exportHTML(to outputURL: URL) async throws {
-		guard let html = await html() else {
+		try await ensureLoaded()
+		guard let html = htmlResult else {
 			throw WebKitBrowserError.missingHTML
 		}
 		try html.write(to: outputURL, atomically: true, encoding: .utf8)
@@ -233,7 +240,12 @@ public class WebKitBrowser: NSObject, WKNavigationDelegate {
 	private func finish(error: Error?) {
 		guard !isFinished else { return }
 		isFinished = true
-		loadError = error
+		// Capturing the page *is* the successful outcome. The frame resize that
+		// follows is cosmetic, so a watchdog or a dying web content process
+		// during that window must not retroactively fail a load whose HTML we
+		// already hold. This keeps the invariant every accessor relies on:
+		// `loadError` is non-nil exactly when there is no HTML.
+		loadError = didLoad ? nil : error
 
 		timeoutTask?.cancel()
 		timeoutTask = nil
@@ -336,6 +348,11 @@ extension WebKitBrowser: WKScriptMessageHandler {
 
 		didLoad = true
 		htmlResult = html
+		// Disarm the watchdog here rather than in `finish(error:)`: the resize
+		// below is an `await`, and the timeout could otherwise fire mid-way and
+		// report a timeout for a page that had in fact loaded.
+		timeoutTask?.cancel()
+		timeoutTask = nil
 
 		Task { @MainActor in
 			// A failed resize is not a failed load — we already have the HTML.

--- a/Tests/SwiftTextHTMLTests/HTMLDocumentTests.swift
+++ b/Tests/SwiftTextHTMLTests/HTMLDocumentTests.swift
@@ -69,4 +69,66 @@ func webKitBrowserLoadsHTML() async throws {
 	let html = await browser.html()
 	#expect(html?.localizedCaseInsensitiveContains("SwiftText") == true)
 }
+
+/// A failed navigation must surface as an error, not hang. Before the
+/// `didFailProvisionalNavigation` handler existed, the injected script never
+/// ran, so nothing ever resumed the waiter and this call blocked forever — the
+/// time limit is what turns a regression into a failure instead of a hung suite.
+@Test(.timeLimit(.minutes(1)))
+@MainActor
+func webKitBrowserReportsNavigationFailure() async throws {
+	// A file that isn't there: fails locally, with no network or DNS in play.
+	// (A refused TCP port is not equivalent — WebKit blocks low ports outright
+	// and reports `didFinish` on an empty document instead of failing.)
+	let missing = FileManager.default.temporaryDirectory
+		.appendingPathComponent("swifttext-missing-\(UUID().uuidString).html")
+	let browser = WebKitBrowser(fileURL: missing, readAccessRoot: FileManager.default.temporaryDirectory)
+	await browser.waitForLoadCompletion()
+
+	#expect(await browser.html() == nil)
+	let error = try #require(browser.loadError as? WebKitBrowserError)
+	guard case .loadFailed = error else {
+		Issue.record("expected .loadFailed, got \(error)")
+		return
+	}
+}
+
+/// The Swift-side backstop fires even when the page itself is fine — proving it
+/// doesn't depend on WebKit calling back at all. The injected script debounces
+/// for 500 ms before posting, so a 50 ms budget always expires first.
+@Test(.timeLimit(.minutes(1)))
+@MainActor
+func webKitBrowserTimesOut() async throws {
+	let browser = WebKitBrowser(htmlString: "<html><body><p>Hello</p></body></html>")
+	browser.timeout = 0.05
+	await browser.waitForLoadCompletion()
+
+	let error = try #require(browser.loadError as? WebKitBrowserError)
+	guard case .timedOut = error else {
+		Issue.record("expected .timedOut, got \(error)")
+		return
+	}
+	// The export methods rethrow it rather than emitting a blank page.
+	await #expect(throws: WebKitBrowserError.self) {
+		_ = try await browser.exportPDFData()
+	}
+}
+
+/// Registering the browser itself as the script-message handler used to close a
+/// cycle — browser → web view → configuration → content controller → browser —
+/// so every load leaked an instance and its web content process.
+@Test(.timeLimit(.minutes(1)))
+@MainActor
+func webKitBrowserDeallocatesAfterLoad() async throws {
+	weak var weakBrowser: WebKitBrowser?
+
+	do {
+		let browser = WebKitBrowser(htmlString: "<html><body><p>Hello</p></body></html>")
+		await browser.waitForLoadCompletion()
+		#expect(await browser.html() != nil)
+		weakBrowser = browser
+	}
+
+	#expect(weakBrowser == nil, "WebKitBrowser leaked — the script-message handler cycle is back")
+}
 #endif

--- a/Tests/SwiftTextHTMLTests/HTMLDocumentTests.swift
+++ b/Tests/SwiftTextHTMLTests/HTMLDocumentTests.swift
@@ -91,6 +91,16 @@ func webKitBrowserReportsNavigationFailure() async throws {
 		Issue.record("expected .loadFailed, got \(error)")
 		return
 	}
+
+	// Every export reports the real cause, not a vague "no HTML". `exportHTML`
+	// used to swallow it and throw `.missingHTML` instead.
+	let destination = FileManager.default.temporaryDirectory
+		.appendingPathComponent("swifttext-export-\(UUID().uuidString).html")
+	defer { try? FileManager.default.removeItem(at: destination) }
+	await #expect(throws: WebKitBrowserError.self) {
+		try await browser.exportHTML(to: destination)
+	}
+	#expect(!FileManager.default.fileExists(atPath: destination.path))
 }
 
 /// The Swift-side backstop fires even when the page itself is fine — proving it


### PR DESCRIPTION
Addresses the "Robustness fixes required first" section of #52. Scoped to exactly those three items — the iOS port and the `HTMLDocument` convenience initializer are **not** in this PR, and neither is PDF export (#55).

## Why

All three are latent on macOS. A CLI process that loads one page and exits papers over every one of them; an app doing repeated loads does not.

## What changed

**1. No failure path.** Only `webView(_:didFinish:)` was implemented. A navigation that failed never ran the injected script, so nothing ever resumed `waitForLoadCompletion()` and the caller waited forever. Added `didFail`, `didFailProvisionalNavigation`, and `webViewWebContentProcessDidTerminate`, all routed through a single idempotent `finish(error:)` — whichever of capture, failure, termination or timeout happens first wins and the rest are no-ops.

**2. Nothing to catch a stall.** The existing 3 s cap is a JS `setTimeout`, so it only fires if the page got far enough to *run* that script. Added a Swift-side `timeout` (default 30 s; `0` waits indefinitely) that guarantees the call returns even if WebKit never calls back at all. That is also the mitigation for the backgrounding case in the issue: iOS suspends or kills the web content process mid-load, and JS timers stop with it. Process termination is now reported explicitly as well, that being the observable form the same failure takes — and the one that *is* reachable on macOS today.

**3. Retain cycle.** `contentController.add(self, name: "pageLoaded")` closed a loop — browser → web view → configuration → content controller → browser — that was never broken with `removeScriptMessageHandler`. Every load leaked an instance and its web content process. The handler is now a weak proxy object, and it is deregistered as soon as the page is captured.

Two further hangs found while in there:

- A second concurrent `waitForLoadCompletion()` overwrote the single stored continuation, stranding the first caller forever. Waiters are now a list, and only the first starts the load.
- A `continuation` property was resumed but never assigned anywhere — dead state on the completion path. Removed.

## Reviewer notes

**No call sites change.** `waitForLoadCompletion()` stays `async` and non-throwing, so all 12 existing callers compile untouched. Failures surface through the new `loadError`, and `exportPDF` / `exportPDFData` / `exportPaginatedPDFData` rethrow it via a shared `loadedWebView()` helper rather than quietly producing a blank PDF. Previously those methods hung; now they throw — strictly better, but it is a behaviour change worth knowing about.

**`timeout` is `TimeInterval`, not `Duration`.** `Duration` needs macOS 13, and this type carries `@available(macOS 10.15, *)`. The `Duration`-based parameter #52 proposes belongs on the future `HTMLDocument` initializer, which is annotated `@available(iOS 14.0, macOS 12.0, *)` and can convert.

**`WebKitBrowserError` gained three cases** (`loadFailed`, `timedOut`, `webContentProcessTerminated`) and now conforms to `LocalizedError`, matching `DocxFileError` / `IWAContainerError`. Adding cases breaks exhaustive switches in any external client.

**No UIKit notification observing.** The file is still `#if os(macOS)`, so `UIApplication.didEnterBackgroundNotification` handling would be dead code here. The timeout plus process-termination handling covers the failure mode; the iOS-specific observer belongs with the port itself.

## Verification

514 tests pass; SwiftLint `--strict` clean. Three tests added, one per fix, each carrying a `.timeLimit` so a regression fails the suite instead of hanging it.

**Each test was confirmed to fail when its fix is reverted**, not just to pass as written:

- Restoring `add(self, …)` → *"WebKitBrowser leaked — the script-message handler cycle is back"*.
- Removing the `didFailProvisionalNavigation` body → the test fails after 30.4 s reporting `.timedOut` instead of `.loadFailed`. That run demonstrates both layers at once: the new watchdog turned a permanent hang into a bounded failure, and the assertion still caught that the specific failure path was gone.

That exercise also corrected the test itself: a refused TCP port does **not** exercise the failure path — WebKit blocks low ports and reports `didFinish` on an empty document (the first draft passed for the wrong reason, taking 3.6 s and returning HTML). It now loads a missing local file, which is a genuine navigation failure and keeps the test off the network entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)